### PR TITLE
chore: CRP-2724 cleanup key manager's package.json

### DIFF
--- a/.github/workflows/key-manager-example.yml
+++ b/.github/workflows/key-manager-example.yml
@@ -32,6 +32,7 @@ jobs:
           popd
           pushd sdk/ic_vetkd_sdk_key_manager_example
           npm install
+          npm test
   key-manager-example-linux:
     runs-on: ubuntu-20.04
     steps:
@@ -47,3 +48,4 @@ jobs:
           popd
           pushd sdk/ic_vetkd_sdk_key_manager_example
           npm install
+          npm test

--- a/.github/workflows/key-manager-example.yml
+++ b/.github/workflows/key-manager-example.yml
@@ -31,7 +31,6 @@ jobs:
           popd
           pushd sdk/ic_vetkd_sdk_key_manager_example
           npm install
-          npm test
   key-manager-example-linux:
     runs-on: ubuntu-20.04
     steps:
@@ -47,4 +46,3 @@ jobs:
           popd
           pushd sdk/ic_vetkd_sdk_key_manager_example
           npm install
-          npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -12054,7 +12054,7 @@
         "sdk/ic_vetkd_sdk_key_manager": {
             "version": "0.1.0",
             "dependencies": {
-                "@dfinity/agent": "^2.3.0",
+                "@dfinity/principal": "^2.3.0",
                 "typescript": "^5.7.3"
             },
             "devDependencies": {

--- a/sdk/ic_vetkd_sdk_key_manager/package.json
+++ b/sdk/ic_vetkd_sdk_key_manager/package.json
@@ -11,6 +11,7 @@
     "peerDependencies": {
         "ic-vetkd-cdk-utils": "^0.1.0"
     },
+    "license": "Apache-2.0",
     "dependencies": {
         "@dfinity/principal": "^2.3.0"
     },

--- a/sdk/ic_vetkd_sdk_key_manager/package.json
+++ b/sdk/ic_vetkd_sdk_key_manager/package.json
@@ -19,7 +19,6 @@
         "typescript": "^5.7.3"
     },
     "scripts": {
-        "build": "tsc",
-        "prepare": "npm run build"
+        "build": "tsc"
     }
 }

--- a/sdk/ic_vetkd_sdk_key_manager/package.json
+++ b/sdk/ic_vetkd_sdk_key_manager/package.json
@@ -12,23 +12,13 @@
         "ic-vetkd-cdk-utils": "^0.1.0"
     },
     "dependencies": {
-        "@dfinity/agent": "^2.3.0",
-        "typescript": "^5.7.3"
+        "@dfinity/principal": "^2.3.0"
     },
     "devDependencies": {
-        "@babel/preset-env": "7.26.0",
-        "@babel/preset-typescript": "7.26.0",
-        "jest": "^29.7.0",
-        "@jest/globals": "^29.7.0",
-        "@types/jest": "^29.5.14",
-        "ts-jest": "^29.2.5",
-        "ts-node": "10.9.2"
+        "typescript": "^5.7.3"
     },
     "scripts": {
         "build": "tsc",
-        "lint": "tslint --project tsconfig.json -t codeFrame 'src/**/*.ts' 'test/**/*.ts'",
-        "prepare": "npm run build",
-        "test": "jest",
-        "test:prod": "npm run lint && npm run test -- --no-cache"
+        "prepare": "npm run build"
     }
 }


### PR DESCRIPTION
Clean up the key manager's package.json:
* Add missing `@dfinity/principal`
* Downgrade `typescript` to dev-dependency
* Remove ts-node dependency, as it seems unused
* Remove things related to babel because they are unused
* Remove things related to jest and testing, because currently there are no tests in this module
* Remove things related to tslint and linting, because tslint [has been deprecated](https://medium.com/palantir/tslint-in-2019-1a144c2317a9) as of 2019

The typescript package is outdated, but this will be fixed in separate PRs so as not to pollute this PR here.

# Before
```
sdk/ic_vetkd_sdk_key_manager/ [main] npx npm-check

@dfinity/agent             😕  NOTUSED?  Still using @dfinity/agent?
                                        Depcheck did not find code similar to require('@dfinity/agent') or import from '@dfinity/agent'.
                                        Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                        Use rc file options to remove unused check, but still monitor for outdated version:
                                            .npmcheckrc {"depcheck": {"ignoreMatches": ["@dfinity/agent"]}}
                                        Use --skip-unused to skip this check.
                                        To remove this package: npm uninstall @dfinity/agent --save

typescript                 😍  UPDATE!   Your local install is out of date. https://www.typescriptlang.org/
                                        npm install typescript@5.8.2 --save to go from 5.7.3 to 5.8.2

@babel/preset-env          😎  PATCH UP  Patch update available. https://babel.dev/docs/en/next/babel-preset-env
                                        npm install @babel/preset-env@7.26.9 --save-dev to go from 7.26.0 to 7.26.9
                           😕  NOTUSED?  Still using @babel/preset-env?
                                        Depcheck did not find code similar to require('@babel/preset-env') or import from '@babel/preset-env'.
                                        Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                        Use rc file options to remove unused check, but still monitor for outdated version:
                                            .npmcheckrc {"depcheck": {"ignoreMatches": ["@babel/preset-env"]}}
                                        Use --skip-unused to skip this check.
                                        To remove this package: npm uninstall @babel/preset-env --save-dev

@babel/preset-typescript   😕  NOTUSED?  Still using @babel/preset-typescript?
                                        Depcheck did not find code similar to require('@babel/preset-typescript') or import from '@babel/preset-typescript'.
                                        Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                        Use rc file options to remove unused check, but still monitor for outdated version:
                                            .npmcheckrc {"depcheck": {"ignoreMatches": ["@babel/preset-typescript"]}}
                                        Use --skip-unused to skip this check.
                                        To remove this package: npm uninstall @babel/preset-typescript --save-dev

@jest/globals              😕  NOTUSED?  Still using @jest/globals?
                                        Depcheck did not find code similar to require('@jest/globals') or import from '@jest/globals'.
                                        Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                        Use rc file options to remove unused check, but still monitor for outdated version:
                                            .npmcheckrc {"depcheck": {"ignoreMatches": ["@jest/globals"]}}
                                        Use --skip-unused to skip this check.
                                        To remove this package: npm uninstall @jest/globals --save-dev

ts-jest                    😍  UPDATE!   Your local install is out of date. https://kulshekhar.github.io/ts-jest
                                        npm install ts-jest@29.2.6 --save-dev to go from 29.2.5 to 29.2.6
                           😕  NOTUSED?  Still using ts-jest?
                                        Depcheck did not find code similar to require('ts-jest') or import from 'ts-jest'.
                                        Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                        Use rc file options to remove unused check, but still monitor for outdated version:
                                            .npmcheckrc {"depcheck": {"ignoreMatches": ["ts-jest"]}}
                                        Use --skip-unused to skip this check.
                                        To remove this package: npm uninstall ts-jest --save-dev

ts-node                    😕  NOTUSED?  Still using ts-node?
                                        Depcheck did not find code similar to require('ts-node') or import from 'ts-node'.
                                        Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                        Use rc file options to remove unused check, but still monitor for outdated version:
                                            .npmcheckrc {"depcheck": {"ignoreMatches": ["ts-node"]}}
                                        Use --skip-unused to skip this check.
                                        To remove this package: npm uninstall ts-node --save-dev

@dfinity/principal         😟  PKG ERR!  Not in the package.json. Found in: /src/index.ts

Use npm-check -u for interactive update.
```

# After
```
sdk/ic_vetkd_sdk_key_manager/ [main*] npx npm-check

typescript   😍  UPDATE!   Your local install is out of date. https://www.typescriptlang.org/
                          npm install typescript@5.8.2 --save-dev to go from 5.7.3 to 5.8.2

Use npm-check -u for interactive update.
```
and
```
sdk/ic_vetkd_sdk_key_manager/ [main*] npx depcheck                         
No depcheck issue
```