### PR TITLE
chore: CRP-2724 fix unused and missing dependencies in encrypted maps SDK

### DIFF
--- a/.github/workflows/encrypted-maps-example.yml
+++ b/.github/workflows/encrypted-maps-example.yml
@@ -7,7 +7,9 @@ on:
   pull_request:
     paths:
       - cdk/**
-      - sdk/ic_vetkd_sdk_{encrypted_maps,encrypted_maps_example,utils}/**
+      - sdk/ic_vetkd_sdk_encrypted_maps/**
+      - sdk/ic_vetkd_sdk_encrypted_maps_example/**
+      - sdk/ic_vetkd_sdk_utils/**
       - .github/workflows/provision-darwin.sh
       - .github/workflows/provision-linux.sh
       - .github/workflows/encrypted-maps-example.yml

--- a/package-lock.json
+++ b/package-lock.json
@@ -12007,20 +12007,12 @@
         "sdk/ic_vetkd_sdk_encrypted_maps": {
             "version": "0.1.0",
             "dependencies": {
-                "@dfinity/agent": "^2.3.0",
-                "typescript": "^5.7.3"
+                "@dfinity/principal": "^2.3.0",
+                "ic-vetkd-cdk-utils": "file:../../cdk/utils/pkg",
+                "idb-keyval": "^6.2.1"
             },
             "devDependencies": {
-                "@babel/preset-env": "7.26.0",
-                "@babel/preset-typescript": "7.26.0",
-                "@jest/globals": "^29.7.0",
-                "@types/jest": "^29.5.14",
-                "jest": "^29.7.0",
-                "ts-jest": "^29.2.5",
-                "ts-node": "10.9.2"
-            },
-            "peerDependencies": {
-                "ic_vetkd_sdk_key_manager": "^0.1.0"
+                "typescript": "^5.7.3"
             }
         },
         "sdk/ic_vetkd_sdk_encrypted_maps_example": {
@@ -12053,18 +12045,12 @@
         },
         "sdk/ic_vetkd_sdk_key_manager": {
             "version": "0.1.0",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@dfinity/principal": "^2.3.0",
-                "typescript": "^5.7.3"
+                "@dfinity/principal": "^2.3.0"
             },
             "devDependencies": {
-                "@babel/preset-env": "7.26.0",
-                "@babel/preset-typescript": "7.26.0",
-                "@jest/globals": "^29.7.0",
-                "@types/jest": "^29.5.14",
-                "jest": "^29.7.0",
-                "ts-jest": "^29.2.5",
-                "ts-node": "10.9.2"
+                "typescript": "^5.7.3"
             },
             "peerDependencies": {
                 "ic-vetkd-cdk-utils": "^0.1.0"

--- a/sdk/ic_vetkd_sdk_encrypted_maps/package.json
+++ b/sdk/ic_vetkd_sdk_encrypted_maps/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ic_vetkd_sdk_encrypted_maps",
   "version": "0.1.0",
+  "license": "Apache-2.0",
   "files": [
     "dist"
   ],
@@ -8,26 +9,16 @@
   "module": "dist/index.es5.js",
   "typings": "dist/types/index.d.ts",
   "peerDependencies": {
-    "ic_vetkd_sdk_key_manager": "^0.1.0"
+    "ic-vetkd-cdk-utils": "^0.1.0"
   },
   "dependencies": {
-    "typescript": "^5.7.3",
-    "@dfinity/agent": "^2.3.0"
+    "@dfinity/principal": "^2.3.0",
+    "idb-keyval": "^6.2.1"
   },
   "devDependencies": {
-    "@babel/preset-env": "7.26.0",
-    "@babel/preset-typescript": "7.26.0",
-    "jest": "^29.7.0",
-    "@jest/globals": "^29.7.0",
-    "@types/jest": "^29.5.14",
-    "ts-jest": "^29.2.5",
-    "ts-node": "10.9.2"
+    "typescript": "^5.7.3"
   },
   "scripts": {
-    "build": "tsc",
-    "lint": "tslint --project tsconfig.json -t codeFrame 'src/**/*.ts' 'test/**/*.ts'",
-    "prepare": "npm run build",
-    "test": "jest",
-    "test:prod": "npm run lint && npm run test -- --no-cache"
+    "build": "tsc"
   }
 }

--- a/sdk/ic_vetkd_sdk_encrypted_maps/src/index.ts
+++ b/sdk/ic_vetkd_sdk_encrypted_maps/src/index.ts
@@ -1,6 +1,6 @@
 import { Principal } from "@dfinity/principal";
 import { get, set } from 'idb-keyval';
-import { TransportSecretKey } from "ic-vetkd-cdk-utils/ic_vetkd_cdk_utils";
+import { TransportSecretKey } from "ic-vetkd-cdk-utils";
 
 export class EncryptedMaps {
     canister_client: EncryptedMapsClient;


### PR DESCRIPTION
## Before
```
sdk/ic_vetkd_sdk_encrypted_maps/ [main*] npx npm-check

typescript                 😍  UPDATE!   Your local install is out of date. https://www.typescriptlang.org/
                                        npm install typescript@5.8.2 --save to go from 5.7.3 to 5.8.2

@dfinity/agent             😕  NOTUSED?  Still using @dfinity/agent?
                                        Depcheck did not find code similar to require('@dfinity/agent') or import from '@dfinity/agent'.
                                        Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                        Use rc file options to remove unused check, but still monitor for outdated version:
                                            .npmcheckrc {"depcheck": {"ignoreMatches": ["@dfinity/agent"]}}
                                        Use --skip-unused to skip this check.
                                        To remove this package: npm uninstall @dfinity/agent --save

@babel/preset-env          😎  PATCH UP  Patch update available. https://babel.dev/docs/en/next/babel-preset-env
                                        npm install @babel/preset-env@7.26.9 --save-dev to go from 7.26.0 to 7.26.9
                           😕  NOTUSED?  Still using @babel/preset-env?
                                        Depcheck did not find code similar to require('@babel/preset-env') or import from '@babel/preset-env'.
                                        Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                        Use rc file options to remove unused check, but still monitor for outdated version:
                                            .npmcheckrc {"depcheck": {"ignoreMatches": ["@babel/preset-env"]}}
                                        Use --skip-unused to skip this check.
                                        To remove this package: npm uninstall @babel/preset-env --save-dev

@babel/preset-typescript   😕  NOTUSED?  Still using @babel/preset-typescript?
                                        Depcheck did not find code similar to require('@babel/preset-typescript') or import from '@babel/preset-typescript'.
                                        Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                        Use rc file options to remove unused check, but still monitor for outdated version:
                                            .npmcheckrc {"depcheck": {"ignoreMatches": ["@babel/preset-typescript"]}}
                                        Use --skip-unused to skip this check.
                                        To remove this package: npm uninstall @babel/preset-typescript --save-dev

@jest/globals              😕  NOTUSED?  Still using @jest/globals?
                                        Depcheck did not find code similar to require('@jest/globals') or import from '@jest/globals'.
                                        Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                        Use rc file options to remove unused check, but still monitor for outdated version:
                                            .npmcheckrc {"depcheck": {"ignoreMatches": ["@jest/globals"]}}
                                        Use --skip-unused to skip this check.
                                        To remove this package: npm uninstall @jest/globals --save-dev

ts-jest                    😍  UPDATE!   Your local install is out of date. https://kulshekhar.github.io/ts-jest
                                        npm install ts-jest@29.2.6 --save-dev to go from 29.2.5 to 29.2.6
                           😕  NOTUSED?  Still using ts-jest?
                                        Depcheck did not find code similar to require('ts-jest') or import from 'ts-jest'.
                                        Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                        Use rc file options to remove unused check, but still monitor for outdated version:
                                            .npmcheckrc {"depcheck": {"ignoreMatches": ["ts-jest"]}}
                                        Use --skip-unused to skip this check.
                                        To remove this package: npm uninstall ts-jest --save-dev

ts-node                    😕  NOTUSED?  Still using ts-node?
                                        Depcheck did not find code similar to require('ts-node') or import from 'ts-node'.
                                        Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                        Use rc file options to remove unused check, but still monitor for outdated version:
                                            .npmcheckrc {"depcheck": {"ignoreMatches": ["ts-node"]}}
                                        Use --skip-unused to skip this check.
                                        To remove this package: npm uninstall ts-node --save-dev

@dfinity/principal         😟  PKG ERR!  Not in the package.json. Found in: /src/index.ts

idb-keyval                 😟  MISSING!  Not installed.
                           😟  PKG ERR!  Not in the package.json. Found in: /src/index.ts

ic-vetkd-cdk-utils         😟  PKG ERR!  Not in the package.json. Found in: /src/index.ts
                           ⛔  NPM ERR!  Registry error Package `ic-vetkd-cdk-utils` could not be found

Use npm-check -u for interactive update.
```

## After
```
sdk/ic_vetkd_sdk_encrypted_maps/ [franzstefan/fix-enc-maps-sdk-deps] npx npm-check

typescript   😍  UPDATE!   Your local install is out of date. https://www.typescriptlang.org/
                          npm install typescript@5.8.2 --save-dev to go from 5.7.3 to 5.8.2

Use npm-check -u for interactive update.
```
and
```
npx depcheck 
No depcheck issue
```
