### PR TITLE
chore: CRP-2732 fix `npm run dev`

### DIFF
--- a/examples/password_manager/deploy_locally.sh
+++ b/examples/password_manager/deploy_locally.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -e
 
 # Check that `dfx` is installed.
 dfx --version >> /dev/null
@@ -26,6 +26,10 @@ pushd frontend
     npm i
     npm run build
 popd
+
+# Store environment variables for the frontend.
+echo "CANISTER_ID_ENCRYPTED_MAPS_EXAMPLE=$CANISTER_ID_ENCRYPTED_MAPS_EXAMPLE" > frontend/.env
+echo "CANISTER_ID_INTERNET_IDENTITY=$CANISTER_ID_INTERNET_IDENTITY" >> frontend/.env
 
 # Deploy the frontend canister.
 dfx deploy www

--- a/examples/password_manager/deploy_locally.sh
+++ b/examples/password_manager/deploy_locally.sh
@@ -28,7 +28,8 @@ pushd frontend
 popd
 
 # Store environment variables for the frontend.
-echo "CANISTER_ID_ENCRYPTED_MAPS_EXAMPLE=$CANISTER_ID_ENCRYPTED_MAPS_EXAMPLE" > frontend/.env
+echo "DFX_NETWORK=$DFX_NETWORK" > frontend/.env
+echo "CANISTER_ID_ENCRYPTED_MAPS_EXAMPLE=$CANISTER_ID_ENCRYPTED_MAPS_EXAMPLE" >> frontend/.env
 echo "CANISTER_ID_INTERNET_IDENTITY=$CANISTER_ID_INTERNET_IDENTITY" >> frontend/.env
 
 # Deploy the frontend canister.

--- a/examples/password_manager/frontend/package.json
+++ b/examples/password_manager/frontend/package.json
@@ -14,6 +14,7 @@
     "svelte": "^4.2.19",
     "tslib": "^2.8.1",
     "vite": "^5.4.14",
+    "vite-plugin-environment": "^1.1.3",
     "vite-plugin-top-level-await": "^1.4.4",
     "vite-plugin-wasm": "^3.4.1"
   },
@@ -22,14 +23,14 @@
     "@dfinity/candid": "^2.3.0",
     "@dfinity/principal": "^2.3.0",
     "@sveltejs/vite-plugin-svelte": "^3.0.2",
+    "@tailwindcss/line-clamp": "^0.4.4",
+    "@tailwindcss/postcss": "^4.0.6",
+    "@tailwindcss/vite": "^4.0.0",
     "autoprefixer": "^10.4.20",
     "rollup-plugin-css-only": "^4.5.2",
     "svelte-icons": "^2.1.0",
     "svelte-spa-router": "^4.0.1",
-    "typewriter-editor": "^0.9.4",
-    "@tailwindcss/line-clamp": "^0.4.4",
-    "@tailwindcss/postcss": "^4.0.6",
-    "@tailwindcss/vite": "^4.0.0",
-    "tailwindcss": "^3.0.17"
+    "tailwindcss": "^3.0.17",
+    "typewriter-editor": "^0.9.4"
   }
 }

--- a/examples/password_manager/frontend/vite.config.js
+++ b/examples/password_manager/frontend/vite.config.js
@@ -6,6 +6,7 @@ import tailwindcss from 'tailwindcss'
 import autoprefixer from "autoprefixer";
 import css from 'rollup-plugin-css-only';
 import typescript from '@rollup/plugin-typescript';
+import environment from 'vite-plugin-environment';
 
 const production = false;// !process.env.VITE_WATCH_MODE;
 
@@ -20,16 +21,13 @@ export default defineConfig({
       sourceMap: true,
       inlineSources: true,
     }),
+    environment("all", { prefix: "CANISTER_" }),
+    environment("all", { prefix: "DFX_" }),
   ],
   esbuild: {
     supported: {
       'top-level-await': true //browsers can handle top-level-await features
     },
-  },
-  define: {
-    'process.env.DFX_NETWORK': JSON.stringify(process.env.DFX_NETWORK),
-    'process.env.CANISTER_ID_INTERNET_IDENTITY': JSON.stringify(process.env.CANISTER_ID_INTERNET_IDENTITY),
-    'process.env.CANISTER_ID_ENCRYPTED_MAPS_EXAMPLE': JSON.stringify(process.env.CANISTER_ID_ENCRYPTED_MAPS_EXAMPLE)
   },
   css: {
     postcss: {

--- a/examples/password_manager_with_metadata/deploy_locally.sh
+++ b/examples/password_manager_with_metadata/deploy_locally.sh
@@ -28,7 +28,8 @@ pushd frontend
 popd
 
 # Store environment variables for the frontend.
-echo "CANISTER_ID_PASSWORD_MANAGER_WITH_METADATA=$CANISTER_ID_PASSWORD_MANAGER_WITH_METADATA" > frontend/.env
+echo "DFX_NETWORK=$DFX_NETWORK" > frontend/.env
+echo "CANISTER_ID_PASSWORD_MANAGER_WITH_METADATA=$CANISTER_ID_PASSWORD_MANAGER_WITH_METADATA" >> frontend/.env
 echo "CANISTER_ID_INTERNET_IDENTITY=$CANISTER_ID_INTERNET_IDENTITY" >> frontend/.env
 
 # Deploy the frontend canister.

--- a/examples/password_manager_with_metadata/deploy_locally.sh
+++ b/examples/password_manager_with_metadata/deploy_locally.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -e
 
 # Check that `dfx` is installed.
 dfx --version >> /dev/null
@@ -26,6 +26,10 @@ pushd frontend
     npm i
     npm run build
 popd
+
+# Store environment variables for the frontend.
+echo "CANISTER_ID_PASSWORD_MANAGER_WITH_METADATA=$CANISTER_ID_PASSWORD_MANAGER_WITH_METADATA" > frontend/.env
+echo "CANISTER_ID_INTERNET_IDENTITY=$CANISTER_ID_INTERNET_IDENTITY" >> frontend/.env
 
 # Deploy the frontend canister.
 dfx deploy www

--- a/examples/password_manager_with_metadata/frontend/package-lock.json
+++ b/examples/password_manager_with_metadata/frontend/package-lock.json
@@ -29,6 +29,7 @@
                 "typescript-eslint": "^8.26.1",
                 "vite": "^5.4.14",
                 "vite-plugin-compression": "^0.5.1",
+                "vite-plugin-environment": "^1.1.3",
                 "vite-plugin-eslint": "^1.8.1",
                 "vite-plugin-top-level-await": "^1.4.4",
                 "vite-plugin-wasm": "^3.4.1"
@@ -5158,6 +5159,16 @@
             },
             "peerDependencies": {
                 "vite": ">=2.0.0"
+            }
+        },
+        "node_modules/vite-plugin-environment": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/vite-plugin-environment/-/vite-plugin-environment-1.1.3.tgz",
+            "integrity": "sha512-9LBhB0lx+2lXVBEWxFZC+WO7PKEyE/ykJ7EPWCq95NEcCpblxamTbs5Dm3DLBGzwODpJMEnzQywJU8fw6XGGGA==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "vite": ">= 2.7"
             }
         },
         "node_modules/vite-plugin-eslint": {

--- a/examples/password_manager_with_metadata/frontend/package.json
+++ b/examples/password_manager_with_metadata/frontend/package.json
@@ -22,6 +22,7 @@
         "typescript-eslint": "^8.26.1",
         "vite": "^5.4.14",
         "vite-plugin-compression": "^0.5.1",
+        "vite-plugin-environment": "^1.1.3",
         "vite-plugin-eslint": "^1.8.1",
         "vite-plugin-top-level-await": "^1.4.4",
         "vite-plugin-wasm": "^3.4.1"

--- a/examples/password_manager_with_metadata/frontend/vite.config.js
+++ b/examples/password_manager_with_metadata/frontend/vite.config.js
@@ -8,6 +8,7 @@ import autoprefixer from "autoprefixer";
 import css from 'rollup-plugin-css-only';
 import typescript from '@rollup/plugin-typescript';
 import viteCompression from 'vite-plugin-compression';
+import environment from 'vite-plugin-environment';
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -20,17 +21,14 @@ export default defineConfig({
     typescript({
       inlineSources: true,
     }),
-    viteCompression()
+    viteCompression(),
+    environment("all", { prefix: "CANISTER_" }),
+    environment("all", { prefix: "DFX_" }),
   ],
   esbuild: {
     supported: {
       'top-level-await': true //browsers can handle top-level-await features
     },
-  },
-  define: {
-    'process.env.DFX_NETWORK': JSON.stringify(process.env.DFX_NETWORK),
-    'process.env.CANISTER_ID_INTERNET_IDENTITY': JSON.stringify(process.env.CANISTER_ID_INTERNET_IDENTITY),
-    'process.env.CANISTER_ID_PASSWORD_MANAGER_WITH_METADATA': JSON.stringify(process.env.CANISTER_ID_PASSWORD_MANAGER_WITH_METADATA)
   },
   css: {
     postcss: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
                 "svelte": "^4.2.19",
                 "tslib": "^2.8.1",
                 "vite": "^5.4.14",
+                "vite-plugin-environment": "^1.1.3",
                 "vite-plugin-top-level-await": "^1.4.4",
                 "vite-plugin-wasm": "^3.4.1"
             }
@@ -11568,6 +11569,16 @@
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/vite-plugin-environment": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/vite-plugin-environment/-/vite-plugin-environment-1.1.3.tgz",
+            "integrity": "sha512-9LBhB0lx+2lXVBEWxFZC+WO7PKEyE/ykJ7EPWCq95NEcCpblxamTbs5Dm3DLBGzwODpJMEnzQywJU8fw6XGGGA==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "vite": ">= 2.7"
             }
         },
         "node_modules/vite-plugin-top-level-await": {


### PR DESCRIPTION
* Write dfx environment variables to an `.env` file.
* Pass the environment variables via `vite-plugin-environment`.