### PR TITLE
chore: CRP-2724 fix dependencies in key manager SDK example

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2385,61 +2385,6 @@
                 "@babel/core": "^7.0.0-0"
             }
         },
-        "node_modules/@babel/register": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.25.9.tgz",
-            "integrity": "sha512-8D43jXtGsYmEeDvm4MWHYUpWf8iiXgWYx3fW7E7Wb7Oe6FWqJPl5K6TuFW0dOwNZzEE5rjlaSJYH9JjrUKJszA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "find-cache-dir": "^2.0.0",
-                "make-dir": "^2.1.0",
-                "pirates": "^4.0.6",
-                "source-map-support": "^0.5.16"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/register/node_modules/make-dir": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-            "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "pify": "^4.0.1",
-                "semver": "^5.6.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/@babel/register/node_modules/semver": {
-            "version": "5.7.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver"
-            }
-        },
-        "node_modules/@babel/register/node_modules/source-map-support": {
-            "version": "0.5.21",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-            "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "buffer-from": "^1.0.0",
-                "source-map": "^0.6.0"
-            }
-        },
         "node_modules/@babel/runtime": {
             "version": "7.26.7",
             "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.7.tgz",
@@ -4814,23 +4759,6 @@
                 "@babel/types": "^7.20.7"
             }
         },
-        "node_modules/@types/chai": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.0.1.tgz",
-            "integrity": "sha512-5T8ajsg3M/FOncpLYW7sdOcD6yf4+722sze/tc4KQV0P8Z2rAr3SAuHCIkYmYpt8VbcQlnz8SxlOlPQYefe4cA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/deep-eql": "*"
-            }
-        },
-        "node_modules/@types/deep-eql": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
-            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@types/estree": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -4899,13 +4827,6 @@
             "dev": true,
             "license": "MIT",
             "peer": true
-        },
-        "node_modules/@types/mocha": {
-            "version": "10.0.10",
-            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
-            "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@types/node": {
             "version": "22.13.0",
@@ -5168,6 +5089,126 @@
                 "fast-diff": "1.3.0"
             }
         },
+        "node_modules/@vitest/coverage-v8": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.0.5.tgz",
+            "integrity": "sha512-zOOWIsj5fHh3jjGwQg+P+J1FW3s4jBu1Zqga0qW60yutsBtqEqNEJKWYh7cYn1yGD+1bdPsPdC/eL4eVK56xMg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@ampproject/remapping": "^2.3.0",
+                "@bcoe/v8-coverage": "^1.0.2",
+                "debug": "^4.4.0",
+                "istanbul-lib-coverage": "^3.2.2",
+                "istanbul-lib-report": "^3.0.1",
+                "istanbul-lib-source-maps": "^5.0.6",
+                "istanbul-reports": "^3.1.7",
+                "magic-string": "^0.30.17",
+                "magicast": "^0.3.5",
+                "std-env": "^3.8.0",
+                "test-exclude": "^7.0.1",
+                "tinyrainbow": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@vitest/browser": "3.0.5",
+                "vitest": "3.0.5"
+            },
+            "peerDependenciesMeta": {
+                "@vitest/browser": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/coverage-v8/node_modules/@bcoe/v8-coverage": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+            "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@vitest/coverage-v8/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/@vitest/coverage-v8/node_modules/glob": {
+            "version": "10.4.5",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+            "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@vitest/coverage-v8/node_modules/istanbul-lib-source-maps": {
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+            "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@jridgewell/trace-mapping": "^0.3.23",
+                "debug": "^4.1.1",
+                "istanbul-lib-coverage": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@vitest/coverage-v8/node_modules/minimatch": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@vitest/coverage-v8/node_modules/test-exclude": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
+            "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@istanbuljs/schema": "^0.1.2",
+                "glob": "^10.4.1",
+                "minimatch": "^9.0.4"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@vitest/expect": {
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.0.5.tgz",
@@ -5343,16 +5384,6 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/ansi-colors": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-            "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/ansi-escapes": {
@@ -5788,13 +5819,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/browser-stdout": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-            "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-            "dev": true,
-            "license": "ISC"
-        },
         "node_modules/browserslist": {
             "version": "4.24.4",
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
@@ -6056,21 +6080,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/clone-deep": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
-            "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-plain-object": "^2.0.4",
-                "kind-of": "^6.0.2",
-                "shallow-clone": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/co": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -6137,13 +6146,6 @@
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-            "license": "MIT"
-        },
-        "node_modules/commondir": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-            "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/concat-map": {
@@ -6363,19 +6365,6 @@
                 "supports-color": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/decamelize": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-            "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/decimal.js": {
@@ -7109,124 +7098,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/find-cache-dir": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
-            "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "commondir": "^1.0.1",
-                "make-dir": "^2.0.0",
-                "pkg-dir": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/find-cache-dir/node_modules/find-up": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-            "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "locate-path": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/find-cache-dir/node_modules/locate-path": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-            "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "p-locate": "^3.0.0",
-                "path-exists": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/find-cache-dir/node_modules/make-dir": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-            "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "pify": "^4.0.1",
-                "semver": "^5.6.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/find-cache-dir/node_modules/p-limit": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "p-try": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/find-cache-dir/node_modules/p-locate": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-            "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "p-limit": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/find-cache-dir/node_modules/path-exists": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-            "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/find-cache-dir/node_modules/pkg-dir": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-            "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "find-up": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/find-cache-dir/node_modules/semver": {
-            "version": "5.7.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver"
-            }
-        },
         "node_modules/find-up": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -7239,16 +7110,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/flat": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-            "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "bin": {
-                "flat": "cli.js"
             }
         },
         "node_modules/flat-cache": {
@@ -7518,16 +7379,6 @@
             },
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/he": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-            "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "he": "bin/he"
             }
         },
         "node_modules/html-encoding-sniffer": {
@@ -7827,29 +7678,6 @@
                 "node": ">=0.12.0"
             }
         },
-        "node_modules/is-plain-obj": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-            "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/is-plain-object": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-            "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "isobject": "^3.0.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/is-potential-custom-element-name": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -7879,19 +7707,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/is-unicode-supported": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-            "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -7905,16 +7720,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/isobject": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-            "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/isomorphic-fetch": {
@@ -8827,16 +8632,6 @@
                 "json-buffer": "3.0.1"
             }
         },
-        "node_modules/kind-of": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-            "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/kleur": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -9159,23 +8954,6 @@
             "license": "MIT",
             "peer": true
         },
-        "node_modules/log-symbols": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-            "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "chalk": "^4.1.0",
-                "is-unicode-supported": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/loupe": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
@@ -9200,6 +8978,18 @@
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.0"
+            }
+        },
+        "node_modules/magicast": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+            "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.25.4",
+                "@babel/types": "^7.25.4",
+                "source-map-js": "^1.2.0"
             }
         },
         "node_modules/make-dir": {
@@ -9336,210 +9126,6 @@
             "license": "ISC",
             "engines": {
                 "node": ">=16 || 14 >=14.17"
-            }
-        },
-        "node_modules/mocha": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.1.0.tgz",
-            "integrity": "sha512-8uJR5RTC2NgpY3GrYcgpZrsEd9zKbPDpob1RezyR2upGHRQtHWofmzTMzTMSV6dru3tj5Ukt0+Vnq1qhFEEwAg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-colors": "^4.1.3",
-                "browser-stdout": "^1.3.1",
-                "chokidar": "^3.5.3",
-                "debug": "^4.3.5",
-                "diff": "^5.2.0",
-                "escape-string-regexp": "^4.0.0",
-                "find-up": "^5.0.0",
-                "glob": "^10.4.5",
-                "he": "^1.2.0",
-                "js-yaml": "^4.1.0",
-                "log-symbols": "^4.1.0",
-                "minimatch": "^5.1.6",
-                "ms": "^2.1.3",
-                "serialize-javascript": "^6.0.2",
-                "strip-json-comments": "^3.1.1",
-                "supports-color": "^8.1.1",
-                "workerpool": "^6.5.1",
-                "yargs": "^17.7.2",
-                "yargs-parser": "^21.1.1",
-                "yargs-unparser": "^2.0.0"
-            },
-            "bin": {
-                "_mocha": "bin/_mocha",
-                "mocha": "bin/mocha.js"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            }
-        },
-        "node_modules/mocha/node_modules/argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true,
-            "license": "Python-2.0"
-        },
-        "node_modules/mocha/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/mocha/node_modules/diff": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-            "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=0.3.1"
-            }
-        },
-        "node_modules/mocha/node_modules/escape-string-regexp": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/mocha/node_modules/find-up": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-            "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "locate-path": "^6.0.0",
-                "path-exists": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/mocha/node_modules/glob": {
-            "version": "10.4.5",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-            "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^3.1.2",
-                "minimatch": "^9.0.4",
-                "minipass": "^7.1.2",
-                "package-json-from-dist": "^1.0.0",
-                "path-scurry": "^1.11.1"
-            },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/mocha/node_modules/glob/node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/mocha/node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^2.0.1"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
-            }
-        },
-        "node_modules/mocha/node_modules/locate-path": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-            "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "p-locate": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/mocha/node_modules/minimatch": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/mocha/node_modules/p-locate": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-            "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "p-limit": "^3.0.2"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/mocha/node_modules/supports-color": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
         "node_modules/ms": {
@@ -9929,16 +9515,6 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
-        "node_modules/pify": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-            "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/pirates": {
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
@@ -10203,16 +9779,6 @@
                 }
             ],
             "license": "MIT"
-        },
-        "node_modules/randombytes": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "safe-buffer": "^5.1.0"
-            }
         },
         "node_modules/react-is": {
             "version": "18.3.1",
@@ -10566,29 +10132,6 @@
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
-            }
-        },
-        "node_modules/serialize-javascript": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "randombytes": "^2.1.0"
-            }
-        },
-        "node_modules/shallow-clone": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
-            "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "kind-of": "^6.0.2"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/shebang-command": {
@@ -11791,13 +11334,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/workerpool": {
-            "version": "6.5.1",
-            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
-            "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
-            "dev": true,
-            "license": "Apache-2.0"
-        },
         "node_modules/wrap-ansi": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -11952,35 +11488,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/yargs-unparser": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-            "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "camelcase": "^6.0.0",
-                "decamelize": "^4.0.0",
-                "flat": "^5.0.2",
-                "is-plain-obj": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/yargs-unparser/node_modules/camelcase": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-            "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/yn": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
@@ -12053,18 +11560,12 @@
         },
         "sdk/ic_vetkd_sdk_key_manager": {
             "version": "0.1.0",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@dfinity/principal": "^2.3.0",
-                "typescript": "^5.7.3"
+                "@dfinity/principal": "^2.3.0"
             },
             "devDependencies": {
-                "@babel/preset-env": "7.26.0",
-                "@babel/preset-typescript": "7.26.0",
-                "@jest/globals": "^29.7.0",
-                "@types/jest": "^29.5.14",
-                "jest": "^29.7.0",
-                "ts-jest": "^29.2.5",
-                "ts-node": "10.9.2"
+                "typescript": "^5.7.3"
             },
             "peerDependencies": {
                 "ic-vetkd-cdk-utils": "^0.1.0"
@@ -12074,35 +11575,24 @@
             "version": "0.1.0",
             "dependencies": {
                 "@dfinity/agent": "^2.3.0",
+                "@dfinity/candid": "^2.3.0",
+                "@dfinity/principal": "^2.3.0",
                 "@types/node": "^22.13.0",
-                "idb-keyval": "^6.2.1",
                 "vite-plugin-top-level-await": "^1.4.4",
                 "vite-plugin-wasm": "^3.4.1"
             },
             "devDependencies": {
-                "@babel/preset-env": "7.26.0",
-                "@babel/preset-typescript": "^7.26.0",
-                "@babel/register": "^7.25.9",
                 "@dfinity/identity": "^2.2.0",
-                "@jest/globals": "^29.7.0",
-                "@types/chai": "^5.0.1",
                 "@types/isomorphic-fetch": "^0.0.39",
-                "@types/jest": "^29.5.14",
-                "@types/mocha": "^10.0.10",
-                "chai": "^5.1.2",
+                "@vitest/coverage-v8": "^3.0.5",
                 "happy-dom": "^17.0.0",
                 "isomorphic-fetch": "^3.0.0",
-                "jest": "^29.7.0",
-                "mocha": "^11.1.0",
-                "ts-jest": "^29.2.5",
-                "ts-node": "^10.9.2",
                 "typescript": "^5.7.3",
                 "vite": "^6.0.11",
                 "vitest": "^3.0.5"
             },
             "peerDependencies": {
-                "ic_vetkd_sdk_key_manager": "^0.1.0",
-                "ic-vetkd-cdk-utils": "^0.1.0"
+                "ic_vetkd_sdk_key_manager": "^0.1.0"
             }
         },
         "sdk/ic_vetkd_sdk_utils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3131,12 +3131,21 @@
             "integrity": "sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@eslint/object-schema": "^2.1.6",
                 "debug": "^4.3.1",
                 "minimatch": "^3.1.2"
             },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/config-helpers": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.1.0.tgz",
+            "integrity": "sha512-kLrdPDJE1ckPo94kmPPf9Hfd0DU0Jw6oKYrhe+pwSC0iTUInmTa+w6fw8sGgcfkFJGNdWOUeOaDM4quW4a7OkA==",
+            "dev": true,
+            "license": "Apache-2.0",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
@@ -3147,7 +3156,6 @@
             "integrity": "sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.15"
             },
@@ -3161,7 +3169,6 @@
             "integrity": "sha512-yaVPAiNAalnCZedKLdR21GOGILMLKPyqSLWaAjQFvYA2i/ciDi8ArYVr69Anohb6cH2Ukhqti4aFnYyPm8wdwQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
@@ -3185,8 +3192,7 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "dev": true,
-            "license": "Python-2.0",
-            "peer": true
+            "license": "Python-2.0"
         },
         "node_modules/@eslint/eslintrc/node_modules/globals": {
             "version": "14.0.0",
@@ -3194,7 +3200,6 @@
             "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -3208,7 +3213,6 @@
             "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -3217,12 +3221,11 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.21.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.21.0.tgz",
-            "integrity": "sha512-BqStZ3HX8Yz6LvsF5ByXYrtigrV5AXADWLAGc7PH/1SxOb7/FIYYMszZZWiUou/GB9P2lXWk2SV4d+Z8h0nknw==",
+            "version": "9.22.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.22.0.tgz",
+            "integrity": "sha512-vLFajx9o8d1/oL2ZkpMYbkLv8nDB6yaIwFNt7nI4+I80U/z03SxmfOMsLbvWr3p7C+Wnoh//aOu2pQW8cS0HCQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
@@ -3233,7 +3236,6 @@
             "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
@@ -3244,7 +3246,6 @@
             "integrity": "sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@eslint/core": "^0.12.0",
                 "levn": "^0.4.1"
@@ -3259,7 +3260,6 @@
             "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": ">=18.18.0"
             }
@@ -3270,7 +3270,6 @@
             "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@humanfs/core": "^0.19.1",
                 "@humanwhocodes/retry": "^0.3.0"
@@ -3285,7 +3284,6 @@
             "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": ">=18.18"
             },
@@ -3300,7 +3298,6 @@
             "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": ">=12.22"
             },
@@ -3315,7 +3312,6 @@
             "integrity": "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": ">=18.18"
             },
@@ -4826,8 +4822,7 @@
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
             "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@types/node": {
             "version": "22.13.0",
@@ -4863,17 +4858,17 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.24.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.24.1.tgz",
-            "integrity": "sha512-ll1StnKtBigWIGqvYDVuDmXJHVH4zLVot1yQ4fJtLpL7qacwkxJc1T0bptqw+miBQ/QfUbhl1TcQ4accW5KUyA==",
+            "version": "8.27.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.27.0.tgz",
+            "integrity": "sha512-4henw4zkePi5p252c8ncBLzLce52SEUz2Ebj8faDnuUXz2UuHEONYcJ+G0oaCF+bYCWVZtrGzq3FD7YXetmnSA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.24.1",
-                "@typescript-eslint/type-utils": "8.24.1",
-                "@typescript-eslint/utils": "8.24.1",
-                "@typescript-eslint/visitor-keys": "8.24.1",
+                "@typescript-eslint/scope-manager": "8.27.0",
+                "@typescript-eslint/type-utils": "8.27.0",
+                "@typescript-eslint/utils": "8.27.0",
+                "@typescript-eslint/visitor-keys": "8.27.0",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.3.1",
                 "natural-compare": "^1.4.0",
@@ -4889,20 +4884,20 @@
             "peerDependencies": {
                 "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.8.0"
+                "typescript": ">=4.8.4 <5.9.0"
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.24.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.24.1.tgz",
-            "integrity": "sha512-Tqoa05bu+t5s8CTZFaGpCH2ub3QeT9YDkXbPd3uQ4SfsLoh1/vv2GEYAioPoxCWJJNsenXlC88tRjwoHNts1oQ==",
+            "version": "8.27.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.27.0.tgz",
+            "integrity": "sha512-XGwIabPallYipmcOk45DpsBSgLC64A0yvdAkrwEzwZ2viqGqRUJ8eEYoPz0CWnutgAFbNMPdsGGvzjSmcWVlEA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.24.1",
-                "@typescript-eslint/types": "8.24.1",
-                "@typescript-eslint/typescript-estree": "8.24.1",
-                "@typescript-eslint/visitor-keys": "8.24.1",
+                "@typescript-eslint/scope-manager": "8.27.0",
+                "@typescript-eslint/types": "8.27.0",
+                "@typescript-eslint/typescript-estree": "8.27.0",
+                "@typescript-eslint/visitor-keys": "8.27.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -4914,18 +4909,18 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.8.0"
+                "typescript": ">=4.8.4 <5.9.0"
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.24.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.24.1.tgz",
-            "integrity": "sha512-OdQr6BNBzwRjNEXMQyaGyZzgg7wzjYKfX2ZBV3E04hUCBDv3GQCHiz9RpqdUIiVrMgJGkXm3tcEh4vFSHreS2Q==",
+            "version": "8.27.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.27.0.tgz",
+            "integrity": "sha512-8oI9GwPMQmBryaaxG1tOZdxXVeMDte6NyJA4i7/TWa4fBwgnAXYlIQP+uYOeqAaLJ2JRxlG9CAyL+C+YE9Xknw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.24.1",
-                "@typescript-eslint/visitor-keys": "8.24.1"
+                "@typescript-eslint/types": "8.27.0",
+                "@typescript-eslint/visitor-keys": "8.27.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4936,14 +4931,14 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.24.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.24.1.tgz",
-            "integrity": "sha512-/Do9fmNgCsQ+K4rCz0STI7lYB4phTtEXqqCAs3gZW0pnK7lWNkvWd5iW545GSmApm4AzmQXmSqXPO565B4WVrw==",
+            "version": "8.27.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.27.0.tgz",
+            "integrity": "sha512-wVArTVcz1oJOIEJxui/nRhV0TXzD/zMSOYi/ggCfNq78EIszddXcJb7r4RCp/oBrjt8n9A0BSxRMKxHftpDxDA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "8.24.1",
-                "@typescript-eslint/utils": "8.24.1",
+                "@typescript-eslint/typescript-estree": "8.27.0",
+                "@typescript-eslint/utils": "8.27.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^2.0.1"
             },
@@ -4956,13 +4951,13 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.8.0"
+                "typescript": ">=4.8.4 <5.9.0"
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.24.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.24.1.tgz",
-            "integrity": "sha512-9kqJ+2DkUXiuhoiYIUvIYjGcwle8pcPpdlfkemGvTObzgmYfJ5d0Qm6jwb4NBXP9W1I5tss0VIAnWFumz3mC5A==",
+            "version": "8.27.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.27.0.tgz",
+            "integrity": "sha512-/6cp9yL72yUHAYq9g6DsAU+vVfvQmd1a8KyA81uvfDE21O2DwQ/qxlM4AR8TSdAu+kJLBDrEHKC5/W2/nxsY0A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4974,14 +4969,14 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.24.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.24.1.tgz",
-            "integrity": "sha512-UPyy4MJ/0RE648DSKQe9g0VDSehPINiejjA6ElqnFaFIhI6ZEiZAkUI0D5MCk0bQcTf/LVqZStvQ6K4lPn/BRg==",
+            "version": "8.27.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.27.0.tgz",
+            "integrity": "sha512-BnKq8cqPVoMw71O38a1tEb6iebEgGA80icSxW7g+kndx0o6ot6696HjG7NdgfuAVmVEtwXUr3L8R9ZuVjoQL6A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.24.1",
-                "@typescript-eslint/visitor-keys": "8.24.1",
+                "@typescript-eslint/types": "8.27.0",
+                "@typescript-eslint/visitor-keys": "8.27.0",
                 "debug": "^4.3.4",
                 "fast-glob": "^3.3.2",
                 "is-glob": "^4.0.3",
@@ -4997,7 +4992,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <5.8.0"
+                "typescript": ">=4.8.4 <5.9.0"
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
@@ -5040,16 +5035,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.24.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.24.1.tgz",
-            "integrity": "sha512-OOcg3PMMQx9EXspId5iktsI3eMaXVwlhC8BvNnX6B5w9a4dVgpkQZuU8Hy67TolKcl+iFWq0XX+jbDGN4xWxjQ==",
+            "version": "8.27.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.27.0.tgz",
+            "integrity": "sha512-njkodcwH1yvmo31YWgRHNb/x1Xhhq4/m81PhtvmRngD8iHPehxffz1SNCO+kwaePhATC+kOa/ggmvPoPza5i0Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
-                "@typescript-eslint/scope-manager": "8.24.1",
-                "@typescript-eslint/types": "8.24.1",
-                "@typescript-eslint/typescript-estree": "8.24.1"
+                "@typescript-eslint/scope-manager": "8.27.0",
+                "@typescript-eslint/types": "8.27.0",
+                "@typescript-eslint/typescript-estree": "8.27.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5060,17 +5055,17 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.8.0"
+                "typescript": ">=4.8.4 <5.9.0"
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.24.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.24.1.tgz",
-            "integrity": "sha512-EwVHlp5l+2vp8CoqJm9KikPZgi3gbdZAtabKT9KPShGeOcJhsv4Zdo3oc8T8I0uKEmYoU4ItyxbptjF08enaxg==",
+            "version": "8.27.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.27.0.tgz",
+            "integrity": "sha512-WsXQwMkILJvffP6z4U3FYJPlbf/j07HIxmDjZpbNvBJkMfvwXj5ACRkkHwBDvLBbDbtX5TdU64/rcvKJ/vuInQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.24.1",
+                "@typescript-eslint/types": "8.27.0",
                 "eslint-visitor-keys": "^4.2.0"
             },
             "engines": {
@@ -5341,7 +5336,6 @@
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
@@ -5375,7 +5369,6 @@
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -6405,8 +6398,7 @@
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/deepmerge": {
             "version": "4.3.1",
@@ -6637,19 +6629,19 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.21.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.21.0.tgz",
-            "integrity": "sha512-KjeihdFqTPhOMXTt7StsDxriV4n66ueuF/jfPNC3j/lduHwr/ijDwJMsF+wyMJethgiKi5wniIE243vi07d3pg==",
+            "version": "9.22.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.22.0.tgz",
+            "integrity": "sha512-9V/QURhsRN40xuHXWjV64yvrzMjcz7ZyNoF2jJFmy9j/SLk0u1OLSZgXi28MrXjymnjEGSR80WCdab3RGMDveQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.12.1",
                 "@eslint/config-array": "^0.19.2",
+                "@eslint/config-helpers": "^0.1.0",
                 "@eslint/core": "^0.12.0",
                 "@eslint/eslintrc": "^3.3.0",
-                "@eslint/js": "9.21.0",
+                "@eslint/js": "9.22.0",
                 "@eslint/plugin-kit": "^0.2.7",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
@@ -6661,7 +6653,7 @@
                 "cross-spawn": "^7.0.6",
                 "debug": "^4.3.2",
                 "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^8.2.0",
+                "eslint-scope": "^8.3.0",
                 "eslint-visitor-keys": "^4.2.0",
                 "espree": "^10.3.0",
                 "esquery": "^1.5.0",
@@ -6698,12 +6690,11 @@
             }
         },
         "node_modules/eslint-scope": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.2.0.tgz",
-            "integrity": "sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==",
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
+            "integrity": "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^5.2.0"
@@ -6734,7 +6725,6 @@
             "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -6748,7 +6738,6 @@
             "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "locate-path": "^6.0.0",
                 "path-exists": "^4.0.0"
@@ -6766,7 +6755,6 @@
             "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "is-glob": "^4.0.3"
             },
@@ -6780,7 +6768,6 @@
             "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "p-locate": "^5.0.0"
             },
@@ -6797,7 +6784,6 @@
             "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "p-limit": "^3.0.2"
             },
@@ -6814,7 +6800,6 @@
             "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "acorn": "^8.14.0",
                 "acorn-jsx": "^5.3.2",
@@ -6847,7 +6832,6 @@
             "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
             "dev": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "dependencies": {
                 "estraverse": "^5.1.0"
             },
@@ -6861,7 +6845,6 @@
             "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "estraverse": "^5.2.0"
             },
@@ -6875,7 +6858,6 @@
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -6974,8 +6956,7 @@
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/fast-diff": {
             "version": "1.3.0",
@@ -7011,8 +6992,7 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/fastparse": {
             "version": "1.1.2",
@@ -7046,7 +7026,6 @@
             "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "flat-cache": "^4.0.0"
             },
@@ -7119,7 +7098,6 @@
             "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "flatted": "^3.2.9",
                 "keyv": "^4.5.4"
@@ -7133,8 +7111,7 @@
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
             "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
             "dev": true,
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
         },
         "node_modules/foreground-child": {
             "version": "3.3.0",
@@ -7525,7 +7502,6 @@
             "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "parent-module": "^1.0.0",
                 "resolve-from": "^4.0.0"
@@ -7543,7 +7519,6 @@
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -8574,8 +8549,7 @@
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
             "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
@@ -8589,16 +8563,14 @@
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/json-text-sequence": {
             "version": "0.1.1",
@@ -8628,7 +8600,6 @@
             "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "json-buffer": "3.0.1"
             }
@@ -8659,7 +8630,6 @@
             "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1",
                 "type-check": "~0.4.0"
@@ -8952,8 +8922,7 @@
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/loupe": {
             "version": "3.1.3",
@@ -9293,7 +9262,6 @@
             "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
@@ -9373,7 +9341,6 @@
             "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "callsites": "^3.0.0"
             },
@@ -9687,7 +9654,6 @@
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">= 0.8.0"
             }
@@ -10684,9 +10650,9 @@
             "license": "MIT"
         },
         "node_modules/ts-api-utils": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.1.tgz",
-            "integrity": "sha512-dnlgjFSVetynI8nzgJ+qF62efpglpWRk8isUEWZGWlJYySCTD6aKvbUDu+zbPeDakk3bg5H4XpitHukgfL1m9w==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+            "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -10821,7 +10787,6 @@
             "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1"
             },
@@ -10853,9 +10818,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.7.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-            "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+            "version": "5.8.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+            "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
@@ -10866,15 +10831,15 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.24.1",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.24.1.tgz",
-            "integrity": "sha512-cw3rEdzDqBs70TIcb0Gdzbt6h11BSs2pS0yaq7hDWDBtCCSei1pPSUXE9qUdQ/Wm9NgFg8mKtMt1b8fTHIl1jA==",
+            "version": "8.27.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.27.0.tgz",
+            "integrity": "sha512-ZZ/8+Y0rRUMuW1gJaPtLWe4ryHbsPLzzibk5Sq+IFa2aOH1Vo0gPr1fbA6pOnzBke7zC2Da4w8AyCgxKXo3lqA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.24.1",
-                "@typescript-eslint/parser": "8.24.1",
-                "@typescript-eslint/utils": "8.24.1"
+                "@typescript-eslint/eslint-plugin": "8.27.0",
+                "@typescript-eslint/parser": "8.27.0",
+                "@typescript-eslint/utils": "8.27.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -10885,7 +10850,7 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.8.0"
+                "typescript": ">=4.8.4 <5.9.0"
             }
         },
         "node_modules/undici-types": {
@@ -10974,7 +10939,6 @@
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "punycode": "^2.1.0"
             }
@@ -11340,7 +11304,6 @@
             "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -11524,13 +11487,19 @@
         },
         "sdk/ic_vetkd_sdk_encrypted_maps": {
             "version": "0.1.0",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@dfinity/principal": "^2.3.0",
-                "ic-vetkd-cdk-utils": "file:../../cdk/utils/pkg",
                 "idb-keyval": "^6.2.1"
             },
             "devDependencies": {
-                "typescript": "^5.7.3"
+                "@eslint/js": "^9.22.0",
+                "eslint": "^9.22.0",
+                "typescript": "^5.8.2",
+                "typescript-eslint": "^8.27.0"
+            },
+            "peerDependencies": {
+                "ic-vetkd-cdk-utils": "^0.1.0"
             }
         },
         "sdk/ic_vetkd_sdk_encrypted_maps_example": {
@@ -11546,14 +11515,17 @@
                 "@babel/preset-env": "7.26.0",
                 "@babel/preset-typescript": "^7.26.0",
                 "@dfinity/identity": "^2.2.0",
+                "@eslint/js": "^9.22.0",
                 "@jest/globals": "^29.7.0",
                 "@types/jest": "^29.5.14",
+                "eslint": "^9.22",
                 "fake-indexeddb": "^6.0.0",
                 "isomorphic-fetch": "3.0.0",
                 "jest": "^29.7.0",
                 "jsdom": "^26.0.0",
                 "ts-jest": "^29.2.5",
                 "ts-node": "10.9.2",
+                "typescript-eslint": "8.27",
                 "vite": "^6.0.5",
                 "vitest": "^3.0.5"
             },
@@ -11568,7 +11540,10 @@
                 "@dfinity/principal": "^2.3.0"
             },
             "devDependencies": {
-                "typescript": "^5.7.3"
+                "@eslint/js": "^9.22.0",
+                "eslint": "^9.22.0",
+                "typescript": "^5.7.3",
+                "typescript-eslint": "8.27"
             },
             "peerDependencies": {
                 "ic-vetkd-cdk-utils": "^0.1.0"
@@ -11586,11 +11561,14 @@
             },
             "devDependencies": {
                 "@dfinity/identity": "^2.2.0",
+                "@eslint/js": "^9.22.0",
                 "@types/isomorphic-fetch": "^0.0.39",
                 "@vitest/coverage-v8": "^3.0.5",
+                "eslint": "^9.22.0",
                 "happy-dom": "^17.0.0",
                 "isomorphic-fetch": "^3.0.0",
                 "typescript": "^5.7.3",
+                "typescript-eslint": "8.27",
                 "vite": "^6.0.11",
                 "vitest": "^3.0.5"
             },
@@ -11608,19 +11586,10 @@
                 "@babel/preset-typescript": "^7.26.0",
                 "@eslint/js": "^9.22.0",
                 "@jest/globals": "^29.7.0",
+                "eslint": "^9.22.0",
                 "jest": "^29.7.0",
                 "typescript": "^5.7.3",
-                "typescript-eslint": "8.24"
-            }
-        },
-        "sdk/ic_vetkd_sdk_utils/node_modules/@eslint/js": {
-            "version": "9.22.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.22.0.tgz",
-            "integrity": "sha512-vLFajx9o8d1/oL2ZkpMYbkLv8nDB6yaIwFNt7nI4+I80U/z03SxmfOMsLbvWr3p7C+Wnoh//aOu2pQW8cS0HCQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+                "typescript-eslint": "8.27"
             }
         }
     }

--- a/sdk/ic_vetkd_sdk_key_manager_example/babel.config.js
+++ b/sdk/ic_vetkd_sdk_key_manager_example/babel.config.js
@@ -1,7 +1,0 @@
-module.exports = {
-    presets: [
-      ['@babel/preset-env', {targets: {node: 'current'}}],
-      '@babel/preset-typescript',
-    ],
-  };
-  

--- a/sdk/ic_vetkd_sdk_key_manager_example/package.json
+++ b/sdk/ic_vetkd_sdk_key_manager_example/package.json
@@ -9,33 +9,22 @@
   "module": "dist/index.es5.js",
   "typings": "dist/types/index.d.ts",
   "peerDependencies": {
-    "ic-vetkd-cdk-utils": "^0.1.0",
     "ic_vetkd_sdk_key_manager": "^0.1.0"
   },
   "dependencies": {
     "@dfinity/agent": "^2.3.0",
+    "@dfinity/candid": "^2.3.0",
+    "@dfinity/principal": "^2.3.0",
     "@types/node": "^22.13.0",
-    "idb-keyval": "^6.2.1",
     "vite-plugin-top-level-await": "^1.4.4",
     "vite-plugin-wasm": "^3.4.1"
   },
   "devDependencies": {
-    "@babel/preset-env": "7.26.0",
-    "@babel/preset-typescript": "^7.26.0",
-    "@babel/register": "^7.25.9",
     "@dfinity/identity": "^2.2.0",
-    "@jest/globals": "^29.7.0",
-    "@types/chai": "^5.0.1",
     "@types/isomorphic-fetch": "^0.0.39",
-    "@types/jest": "^29.5.14",
-    "@types/mocha": "^10.0.10",
-    "chai": "^5.1.2",
+    "@vitest/coverage-v8": "^3.0.5",
     "happy-dom": "^17.0.0",
     "isomorphic-fetch": "^3.0.0",
-    "jest": "^29.7.0",
-    "mocha": "^11.1.0",
-    "ts-jest": "^29.2.5",
-    "ts-node": "^10.9.2",
     "typescript": "^5.7.3",
     "vite": "^6.0.11",
     "vitest": "^3.0.5"
@@ -43,8 +32,6 @@
   "scripts": {
     "build": "tsc && vite build",
     "coverage": "vitest run --coverage",
-    "test": "vitest",
-    "lint": "tslint --project tsconfig.json -t codeFrame 'src/**/*.ts' 'test/**/*.ts'",
-    "test:prod": "npm run lint && npm run test -- --no-cache"
+    "test": "vitest"
   }
 }

--- a/sdk/ic_vetkd_sdk_key_manager_example/package.json
+++ b/sdk/ic_vetkd_sdk_key_manager_example/package.json
@@ -21,14 +21,14 @@
   },
   "devDependencies": {
     "@dfinity/identity": "^2.2.0",
+    "@eslint/js": "^9.22.0",
     "@types/isomorphic-fetch": "^0.0.39",
     "@vitest/coverage-v8": "^3.0.5",
-    "@eslint/js": "^9.22.0",
     "eslint": "^9.22.0",
     "happy-dom": "^17.0.0",
     "isomorphic-fetch": "^3.0.0",
-    "typescript": "^5.7.3",
     "typescript-eslint": "8.27",
+    "typescript": "^5.7.3",
     "vite": "^6.0.11",
     "vitest": "^3.0.5"
   },

--- a/sdk/ic_vetkd_sdk_key_manager_example/src/index.ts
+++ b/sdk/ic_vetkd_sdk_key_manager_example/src/index.ts
@@ -3,8 +3,6 @@ import { ActorSubclass, HttpAgent } from "@dfinity/agent";
 import { createActor } from "./declarations/key_manager_example/index.js";
 import { _SERVICE as _DEFAULT_KEY_MANAGER_SERVICE, AccessRights, ByteBuf } from "./declarations/key_manager_example/key_manager_example.did.js";
 import { KeyManagerClient } from "ic_vetkd_sdk_key_manager/src/index.js";
-import { TransportSecretKey } from "ic-vetkd-cdk-utils/ic_vetkd_cdk_utils.js";
-import { get, set } from 'idb-keyval';
 
 export class DefaultKeyManagerClient implements KeyManagerClient {
     canisterId: string;


### PR DESCRIPTION
## Before
```
sdk/ic_vetkd_sdk_key_manager_example/ [main*] npx npm-check

@types/node                   😍  UPDATE!   Your local install is out of date. https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node
                                           npm install @types/node@22.13.10 --save to go from 22.13.0 to 22.13.10

vite-plugin-top-level-await   😍  UPDATE!   Your local install is out of date. https://github.com/Menci/vite-plugin-top-level-await#readme
                                           npm install vite-plugin-top-level-await@1.5.0 --save to go from 1.4.4 to 1.5.0

@babel/preset-env             😎  PATCH UP  Patch update available. https://babel.dev/docs/en/next/babel-preset-env
                                           npm install @babel/preset-env@7.26.9 --save-dev to go from 7.26.0 to 7.26.9

@babel/register               😕  NOTUSED?  Still using @babel/register?
                                           Depcheck did not find code similar to require('@babel/register') or import from '@babel/register'.
                                           Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                           Use rc file options to remove unused check, but still monitor for outdated version:
                                               .npmcheckrc {"depcheck": {"ignoreMatches": ["@babel/register"]}}
                                           Use --skip-unused to skip this check.
                                           To remove this package: npm uninstall @babel/register --save-dev

@jest/globals                 😕  NOTUSED?  Still using @jest/globals?
                                           Depcheck did not find code similar to require('@jest/globals') or import from '@jest/globals'.
                                           Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                           Use rc file options to remove unused check, but still monitor for outdated version:
                                               .npmcheckrc {"depcheck": {"ignoreMatches": ["@jest/globals"]}}
                                           Use --skip-unused to skip this check.
                                           To remove this package: npm uninstall @jest/globals --save-dev

@types/chai                   😍  UPDATE!   Your local install is out of date. https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/chai
                                           npm install @types/chai@5.2.0 --save-dev to go from 5.0.1 to 5.2.0

chai                          😍  UPDATE!   Your local install is out of date. http://chaijs.com
                                           npm install chai@5.2.0 --save-dev to go from 5.1.2 to 5.2.0
                              😕  NOTUSED?  Still using chai?
                                           Depcheck did not find code similar to require('chai') or import from 'chai'.
                                           Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                           Use rc file options to remove unused check, but still monitor for outdated version:
                                               .npmcheckrc {"depcheck": {"ignoreMatches": ["chai"]}}
                                           Use --skip-unused to skip this check.
                                           To remove this package: npm uninstall chai --save-dev

happy-dom                     😍  UPDATE!   Your local install is out of date. https://github.com/capricorn86/happy-dom
                                           npm install happy-dom@17.4.4 --save-dev to go from 17.0.0 to 17.4.4

jest                          😕  NOTUSED?  Still using jest?
                                           Depcheck did not find code similar to require('jest') or import from 'jest'.
                                           Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                           Use rc file options to remove unused check, but still monitor for outdated version:
                                               .npmcheckrc {"depcheck": {"ignoreMatches": ["jest"]}}
                                           Use --skip-unused to skip this check.
                                           To remove this package: npm uninstall jest --save-dev

ts-jest                       😍  UPDATE!   Your local install is out of date. https://kulshekhar.github.io/ts-jest
                                           npm install ts-jest@29.2.6 --save-dev to go from 29.2.5 to 29.2.6
                              😕  NOTUSED?  Still using ts-jest?
                                           Depcheck did not find code similar to require('ts-jest') or import from 'ts-jest'.
                                           Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                           Use rc file options to remove unused check, but still monitor for outdated version:
                                               .npmcheckrc {"depcheck": {"ignoreMatches": ["ts-jest"]}}
                                           Use --skip-unused to skip this check.
                                           To remove this package: npm uninstall ts-jest --save-dev

ts-node                       😕  NOTUSED?  Still using ts-node?
                                           Depcheck did not find code similar to require('ts-node') or import from 'ts-node'.
                                           Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                           Use rc file options to remove unused check, but still monitor for outdated version:
                                               .npmcheckrc {"depcheck": {"ignoreMatches": ["ts-node"]}}
                                           Use --skip-unused to skip this check.
                                           To remove this package: npm uninstall ts-node --save-dev

typescript                    😍  UPDATE!   Your local install is out of date. https://www.typescriptlang.org/
                                           npm install typescript@5.8.2 --save-dev to go from 5.7.3 to 5.8.2

vite                          😍  UPDATE!   Your local install is out of date. https://vite.dev
                                           npm install vite@6.2.2 --save-dev to go from 6.1.0 to 6.2.2

vitest                        😍  UPDATE!   Your local install is out of date. https://github.com/vitest-dev/vitest#readme
                                           npm install vitest@3.0.9 --save-dev to go from 3.0.5 to 3.0.9

@dfinity/principal            😟  PKG ERR!  Not in the package.json. Found in: /src/index.ts, /src/declarations/key_manager_example/index.d.ts, /src/declarations/key_manager_example/key_manager_example.did.d.ts

@dfinity/candid               😟  PKG ERR!  Not in the package.json. Found in: /src/declarations/key_manager_example/index.d.ts, /src/declarations/key_manager_example/key_manager_example.did.d.ts

Use npm-check -u for interactive update.
```

## After
```
sdk/ic_vetkd_sdk_key_manager_example/ [franzstefan/fix-key-mgr-example-deps] npx npm-check                      

@types/node                   😍  UPDATE!   Your local install is out of date. https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node
                                           npm install @types/node@22.13.11 --save to go from 22.13.0 to 22.13.11

vite-plugin-top-level-await   😍  UPDATE!   Your local install is out of date. https://github.com/Menci/vite-plugin-top-level-await#readme
                                           npm install vite-plugin-top-level-await@1.5.0 --save to go from 1.4.4 to 1.5.0

@vitest/coverage-v8           😍  UPDATE!   Your local install is out of date. https://github.com/vitest-dev/vitest/tree/main/packages/coverage-v8#readme
                                           npm install @vitest/coverage-v8@3.0.9 --save-dev to go from 3.0.5 to 3.0.9
                              😕  NOTUSED?  Still using @vitest/coverage-v8?
                                           Depcheck did not find code similar to require('@vitest/coverage-v8') or import from '@vitest/coverage-v8'.
                                           Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                           Use rc file options to remove unused check, but still monitor for outdated version:
                                               .npmcheckrc {"depcheck": {"ignoreMatches": ["@vitest/coverage-v8"]}}
                                           Use --skip-unused to skip this check.
                                           To remove this package: npm uninstall @vitest/coverage-v8 --save-dev

happy-dom                     😍  UPDATE!   Your local install is out of date. https://github.com/capricorn86/happy-dom
                                           npm install happy-dom@17.4.4 --save-dev to go from 17.0.0 to 17.4.4

typescript                    😍  UPDATE!   Your local install is out of date. https://www.typescriptlang.org/
                                           npm install typescript@5.8.2 --save-dev to go from 5.7.3 to 5.8.2

vite                          😍  UPDATE!   Your local install is out of date. https://vite.dev
                                           npm install vite@6.2.2 --save-dev to go from 6.1.0 to 6.2.2

vitest                        😍  UPDATE!   Your local install is out of date. https://github.com/vitest-dev/vitest#readme
                                           npm install vitest@3.0.9 --save-dev to go from 3.0.5 to 3.0.9

Use npm-check -u for interactive update.
```
and
```
sdk/ic_vetkd_sdk_key_manager_example/ [franzstefan/fix-key-mgr-example-deps] npx depcheck 
Unused devDependencies
* @vitest/coverage-v8
```

## Notes
The reported unused `@vitest/coverage-v8` is a false positive, because it is used by the following script in `package.json`:
```
"coverage": "vitest run --coverage",
```