### PR TITLE
chore: CRP-2724 fix dependencies in encrypted maps SDK example

### DIFF
--- a/.github/workflows/examples-password-manager.yml
+++ b/.github/workflows/examples-password-manager.yml
@@ -9,7 +9,7 @@ on:
       - examples/password_manager/**
       - cdk/**
       - sdk/ic_vetkd_sdk_encrypted_maps/**
-      - sdk/ic_vetkd_sdk_encrypted_maps_example,utils/**
+      - sdk/ic_vetkd_sdk_encrypted_maps_example/**
       - sdk/ic_vetkd_sdk_utils/**
       - .github/workflows/provision-darwin.sh
       - .github/workflows/provision-linux.sh

--- a/package-lock.json
+++ b/package-lock.json
@@ -2462,8 +2462,9 @@
             "version": "0.8.1",
             "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
             "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-            "devOptional": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@jridgewell/trace-mapping": "0.3.9"
             },
@@ -2475,8 +2476,9 @@
             "version": "0.3.9",
             "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
             "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-            "devOptional": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.0.3",
                 "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -4701,29 +4703,33 @@
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
             "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
-            "devOptional": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/@tsconfig/node12": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
             "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-            "devOptional": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/@tsconfig/node14": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
             "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-            "devOptional": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/@tsconfig/node16": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
             "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-            "devOptional": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
@@ -4818,17 +4824,6 @@
             "license": "MIT",
             "dependencies": {
                 "@types/istanbul-lib-report": "*"
-            }
-        },
-        "node_modules/@types/jest": {
-            "version": "29.5.14",
-            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
-            "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "expect": "^29.0.0",
-                "pretty-format": "^29.0.0"
             }
         },
         "node_modules/@types/json-schema": {
@@ -5220,126 +5215,6 @@
             }
         },
         "node_modules/@vitest/expect": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.0.5.tgz",
-            "integrity": "sha512-nNIOqupgZ4v5jWuQx2DSlHLEs7Q4Oh/7AYwNyE+k0UQzG7tSmjPXShUikn1mpNGzYEN2jJbTvLejwShMitovBA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@ampproject/remapping": "^2.3.0",
-                "@bcoe/v8-coverage": "^1.0.2",
-                "debug": "^4.4.0",
-                "istanbul-lib-coverage": "^3.2.2",
-                "istanbul-lib-report": "^3.0.1",
-                "istanbul-lib-source-maps": "^5.0.6",
-                "istanbul-reports": "^3.1.7",
-                "magic-string": "^0.30.17",
-                "magicast": "^0.3.5",
-                "std-env": "^3.8.0",
-                "test-exclude": "^7.0.1",
-                "tinyrainbow": "^2.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            },
-            "peerDependencies": {
-                "@vitest/browser": "3.0.9",
-                "vitest": "3.0.9"
-            },
-            "peerDependenciesMeta": {
-                "@vitest/browser": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@vitest/coverage-v8/node_modules/@bcoe/v8-coverage": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
-            "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@vitest/coverage-v8/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/@vitest/coverage-v8/node_modules/glob": {
-            "version": "10.4.5",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-            "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^3.1.2",
-                "minimatch": "^9.0.4",
-                "minipass": "^7.1.2",
-                "package-json-from-dist": "^1.0.0",
-                "path-scurry": "^1.11.1"
-            },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@vitest/coverage-v8/node_modules/istanbul-lib-source-maps": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
-            "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@jridgewell/trace-mapping": "^0.3.23",
-                "debug": "^4.1.1",
-                "istanbul-lib-coverage": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@vitest/coverage-v8/node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@vitest/coverage-v8/node_modules/test-exclude": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
-            "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "@istanbuljs/schema": "^0.1.2",
-                "glob": "^10.4.1",
-                "minimatch": "^9.0.4"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@vitest/expect": {
             "version": "3.0.9",
             "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.0.9.tgz",
             "integrity": "sha512-5eCqRItYgIML7NNVgJj6TVCmdzE7ZVgJhruW0ziSQV4V7PvLkDL1bBkBdcTs/VuIz0IxPb5da1IDSqc1TR9eig==",
@@ -5478,8 +5353,9 @@
             "version": "8.3.4",
             "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
             "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-            "devOptional": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "acorn": "^8.11.0"
             },
@@ -5579,8 +5455,9 @@
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
             "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-            "devOptional": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/argparse": {
             "version": "1.0.10",
@@ -5610,13 +5487,6 @@
             "engines": {
                 "node": ">=12"
             }
-        },
-        "node_modules/async": {
-            "version": "3.2.6",
-            "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-            "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/asynckit": {
             "version": "0.4.0",
@@ -5983,19 +5853,6 @@
                 "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
             }
         },
-        "node_modules/bs-logger": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
-            "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-json-stable-stringify": "2.x"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/bser": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -6336,8 +6193,9 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
             "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-            "devOptional": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
@@ -6611,8 +6469,9 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
             "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-            "devOptional": true,
             "license": "BSD-3-Clause",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.3.1"
             }
@@ -6638,22 +6497,6 @@
             "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
             "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
             "license": "MIT"
-        },
-        "node_modules/ejs": {
-            "version": "3.1.10",
-            "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
-            "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "jake": "^10.8.5"
-            },
-            "bin": {
-                "ejs": "bin/cli.js"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/electron-to-chromium": {
             "version": "1.5.90",
@@ -7187,39 +7030,6 @@
             },
             "engines": {
                 "node": ">=16.0.0"
-            }
-        },
-        "node_modules/filelist": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
-            "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "minimatch": "^5.0.1"
-            }
-        },
-        "node_modules/filelist/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/filelist/node_modules/minimatch": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/fill-range": {
@@ -7974,25 +7784,6 @@
             },
             "optionalDependencies": {
                 "@pkgjs/parseargs": "^0.11.0"
-            }
-        },
-        "node_modules/jake": {
-            "version": "10.9.2",
-            "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
-            "integrity": "sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "async": "^3.2.3",
-                "chalk": "^4.0.2",
-                "filelist": "^1.0.4",
-                "minimatch": "^3.1.2"
-            },
-            "bin": {
-                "jake": "bin/cli.js"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/jest": {
@@ -9086,13 +8877,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/lodash.memoize": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-            "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -9171,8 +8955,9 @@
             "version": "1.3.6",
             "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
             "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-            "devOptional": true,
-            "license": "ISC"
+            "license": "ISC",
+            "optional": true,
+            "peer": true
         },
         "node_modules/makeerror": {
             "version": "1.0.12",
@@ -10866,74 +10651,13 @@
             "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
             "license": "Apache-2.0"
         },
-        "node_modules/ts-jest": {
-            "version": "29.2.5",
-            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.2.5.tgz",
-            "integrity": "sha512-KD8zB2aAZrcKIdGk4OwpJggeLcH1FgrICqDSROWqlnJXGCXK4Mn6FcdK2B6670Xr73lHMG1kHw8R87A0ecZ+vA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "bs-logger": "^0.2.6",
-                "ejs": "^3.1.10",
-                "fast-json-stable-stringify": "^2.1.0",
-                "jest-util": "^29.0.0",
-                "json5": "^2.2.3",
-                "lodash.memoize": "^4.1.2",
-                "make-error": "^1.3.6",
-                "semver": "^7.6.3",
-                "yargs-parser": "^21.1.1"
-            },
-            "bin": {
-                "ts-jest": "cli.js"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
-            },
-            "peerDependencies": {
-                "@babel/core": ">=7.0.0-beta.0 <8",
-                "@jest/transform": "^29.0.0",
-                "@jest/types": "^29.0.0",
-                "babel-jest": "^29.0.0",
-                "jest": "^29.0.0",
-                "typescript": ">=4.3 <6"
-            },
-            "peerDependenciesMeta": {
-                "@babel/core": {
-                    "optional": true
-                },
-                "@jest/transform": {
-                    "optional": true
-                },
-                "@jest/types": {
-                    "optional": true
-                },
-                "babel-jest": {
-                    "optional": true
-                },
-                "esbuild": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/ts-jest/node_modules/semver": {
-            "version": "7.7.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
-            "integrity": "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/ts-node": {
             "version": "10.9.2",
             "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
             "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-            "devOptional": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@cspotcode/source-map-support": "^0.8.0",
                 "@tsconfig/node10": "^1.0.7",
@@ -11164,8 +10888,9 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
             "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-            "devOptional": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/v8-to-istanbul": {
             "version": "9.3.0",
@@ -11676,8 +11401,9 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
             "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-            "devOptional": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -11714,6 +11440,7 @@
         },
         "sdk/ic_vetkd_sdk_encrypted_maps_example": {
             "version": "0.1.0",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@dfinity/agent": "^2.3.0",
                 "@dfinity/candid": "^2.3.0",
@@ -11725,15 +11452,10 @@
             "devDependencies": {
                 "@dfinity/identity": "^2.2.0",
                 "@eslint/js": "^9.22.0",
-                "@jest/globals": "^29.7.0",
-                "@types/jest": "^29.5.14",
+                "@vitest/coverage-v8": "^3.0.5",
                 "eslint": "^9.22",
                 "fake-indexeddb": "^6.0.0",
                 "isomorphic-fetch": "3.0.0",
-                "jest": "^29.7.0",
-                "jsdom": "^26.0.0",
-                "ts-jest": "^29.2.5",
-                "ts-node": "10.9.2",
                 "typescript-eslint": "8.27",
                 "vite": "^6.0.5",
                 "vitest": "^3.0.5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -672,6 +672,8 @@
             "integrity": "sha512-GIc76d9UI1hCvOATjZPyHFmE5qhRccp3/zGfMPapK3jBi+yocEzp6BBB0UnfRYP9NP4FANqUZYb0hnfs3TM3hw==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@csstools/css-calc": "^2.1.1",
                 "@csstools/css-color-parser": "^3.0.7",
@@ -685,7 +687,9 @@
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
             "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
             "dev": true,
-            "license": "ISC"
+            "license": "ISC",
+            "optional": true,
+            "peer": true
         },
         "node_modules/@babel/code-frame": {
             "version": "7.26.2",
@@ -2549,6 +2553,8 @@
                 }
             ],
             "license": "MIT-0",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2569,6 +2575,8 @@
                 }
             ],
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -2593,6 +2601,8 @@
                 }
             ],
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@csstools/color-helpers": "^5.0.1",
                 "@csstools/css-calc": "^2.1.1"
@@ -2621,6 +2631,8 @@
                 }
             ],
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -2644,6 +2656,8 @@
                 }
             ],
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -3186,12 +3200,21 @@
             "integrity": "sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@eslint/object-schema": "^2.1.6",
                 "debug": "^4.3.1",
                 "minimatch": "^3.1.2"
             },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/config-helpers": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.1.0.tgz",
+            "integrity": "sha512-kLrdPDJE1ckPo94kmPPf9Hfd0DU0Jw6oKYrhe+pwSC0iTUInmTa+w6fw8sGgcfkFJGNdWOUeOaDM4quW4a7OkA==",
+            "dev": true,
+            "license": "Apache-2.0",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
@@ -3202,7 +3225,6 @@
             "integrity": "sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.15"
             },
@@ -3216,7 +3238,6 @@
             "integrity": "sha512-yaVPAiNAalnCZedKLdR21GOGILMLKPyqSLWaAjQFvYA2i/ciDi8ArYVr69Anohb6cH2Ukhqti4aFnYyPm8wdwQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
@@ -3240,8 +3261,7 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "dev": true,
-            "license": "Python-2.0",
-            "peer": true
+            "license": "Python-2.0"
         },
         "node_modules/@eslint/eslintrc/node_modules/globals": {
             "version": "14.0.0",
@@ -3249,7 +3269,6 @@
             "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -3263,7 +3282,6 @@
             "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -3272,12 +3290,11 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.21.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.21.0.tgz",
-            "integrity": "sha512-BqStZ3HX8Yz6LvsF5ByXYrtigrV5AXADWLAGc7PH/1SxOb7/FIYYMszZZWiUou/GB9P2lXWk2SV4d+Z8h0nknw==",
+            "version": "9.22.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.22.0.tgz",
+            "integrity": "sha512-vLFajx9o8d1/oL2ZkpMYbkLv8nDB6yaIwFNt7nI4+I80U/z03SxmfOMsLbvWr3p7C+Wnoh//aOu2pQW8cS0HCQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
@@ -3288,7 +3305,6 @@
             "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
@@ -3299,7 +3315,6 @@
             "integrity": "sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@eslint/core": "^0.12.0",
                 "levn": "^0.4.1"
@@ -3314,7 +3329,6 @@
             "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": ">=18.18.0"
             }
@@ -3325,7 +3339,6 @@
             "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@humanfs/core": "^0.19.1",
                 "@humanwhocodes/retry": "^0.3.0"
@@ -3340,7 +3353,6 @@
             "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": ">=18.18"
             },
@@ -3355,7 +3367,6 @@
             "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": ">=12.22"
             },
@@ -3370,7 +3381,6 @@
             "integrity": "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": ">=18.18"
             },
@@ -4898,8 +4908,7 @@
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
             "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@types/mocha": {
             "version": "10.0.10",
@@ -4942,17 +4951,17 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.24.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.24.1.tgz",
-            "integrity": "sha512-ll1StnKtBigWIGqvYDVuDmXJHVH4zLVot1yQ4fJtLpL7qacwkxJc1T0bptqw+miBQ/QfUbhl1TcQ4accW5KUyA==",
+            "version": "8.27.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.27.0.tgz",
+            "integrity": "sha512-4henw4zkePi5p252c8ncBLzLce52SEUz2Ebj8faDnuUXz2UuHEONYcJ+G0oaCF+bYCWVZtrGzq3FD7YXetmnSA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.24.1",
-                "@typescript-eslint/type-utils": "8.24.1",
-                "@typescript-eslint/utils": "8.24.1",
-                "@typescript-eslint/visitor-keys": "8.24.1",
+                "@typescript-eslint/scope-manager": "8.27.0",
+                "@typescript-eslint/type-utils": "8.27.0",
+                "@typescript-eslint/utils": "8.27.0",
+                "@typescript-eslint/visitor-keys": "8.27.0",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.3.1",
                 "natural-compare": "^1.4.0",
@@ -4968,20 +4977,20 @@
             "peerDependencies": {
                 "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.8.0"
+                "typescript": ">=4.8.4 <5.9.0"
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.24.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.24.1.tgz",
-            "integrity": "sha512-Tqoa05bu+t5s8CTZFaGpCH2ub3QeT9YDkXbPd3uQ4SfsLoh1/vv2GEYAioPoxCWJJNsenXlC88tRjwoHNts1oQ==",
+            "version": "8.27.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.27.0.tgz",
+            "integrity": "sha512-XGwIabPallYipmcOk45DpsBSgLC64A0yvdAkrwEzwZ2viqGqRUJ8eEYoPz0CWnutgAFbNMPdsGGvzjSmcWVlEA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.24.1",
-                "@typescript-eslint/types": "8.24.1",
-                "@typescript-eslint/typescript-estree": "8.24.1",
-                "@typescript-eslint/visitor-keys": "8.24.1",
+                "@typescript-eslint/scope-manager": "8.27.0",
+                "@typescript-eslint/types": "8.27.0",
+                "@typescript-eslint/typescript-estree": "8.27.0",
+                "@typescript-eslint/visitor-keys": "8.27.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -4993,18 +5002,18 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.8.0"
+                "typescript": ">=4.8.4 <5.9.0"
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.24.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.24.1.tgz",
-            "integrity": "sha512-OdQr6BNBzwRjNEXMQyaGyZzgg7wzjYKfX2ZBV3E04hUCBDv3GQCHiz9RpqdUIiVrMgJGkXm3tcEh4vFSHreS2Q==",
+            "version": "8.27.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.27.0.tgz",
+            "integrity": "sha512-8oI9GwPMQmBryaaxG1tOZdxXVeMDte6NyJA4i7/TWa4fBwgnAXYlIQP+uYOeqAaLJ2JRxlG9CAyL+C+YE9Xknw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.24.1",
-                "@typescript-eslint/visitor-keys": "8.24.1"
+                "@typescript-eslint/types": "8.27.0",
+                "@typescript-eslint/visitor-keys": "8.27.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5015,14 +5024,14 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.24.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.24.1.tgz",
-            "integrity": "sha512-/Do9fmNgCsQ+K4rCz0STI7lYB4phTtEXqqCAs3gZW0pnK7lWNkvWd5iW545GSmApm4AzmQXmSqXPO565B4WVrw==",
+            "version": "8.27.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.27.0.tgz",
+            "integrity": "sha512-wVArTVcz1oJOIEJxui/nRhV0TXzD/zMSOYi/ggCfNq78EIszddXcJb7r4RCp/oBrjt8n9A0BSxRMKxHftpDxDA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "8.24.1",
-                "@typescript-eslint/utils": "8.24.1",
+                "@typescript-eslint/typescript-estree": "8.27.0",
+                "@typescript-eslint/utils": "8.27.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^2.0.1"
             },
@@ -5035,13 +5044,13 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.8.0"
+                "typescript": ">=4.8.4 <5.9.0"
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.24.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.24.1.tgz",
-            "integrity": "sha512-9kqJ+2DkUXiuhoiYIUvIYjGcwle8pcPpdlfkemGvTObzgmYfJ5d0Qm6jwb4NBXP9W1I5tss0VIAnWFumz3mC5A==",
+            "version": "8.27.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.27.0.tgz",
+            "integrity": "sha512-/6cp9yL72yUHAYq9g6DsAU+vVfvQmd1a8KyA81uvfDE21O2DwQ/qxlM4AR8TSdAu+kJLBDrEHKC5/W2/nxsY0A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5053,14 +5062,14 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.24.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.24.1.tgz",
-            "integrity": "sha512-UPyy4MJ/0RE648DSKQe9g0VDSehPINiejjA6ElqnFaFIhI6ZEiZAkUI0D5MCk0bQcTf/LVqZStvQ6K4lPn/BRg==",
+            "version": "8.27.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.27.0.tgz",
+            "integrity": "sha512-BnKq8cqPVoMw71O38a1tEb6iebEgGA80icSxW7g+kndx0o6ot6696HjG7NdgfuAVmVEtwXUr3L8R9ZuVjoQL6A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.24.1",
-                "@typescript-eslint/visitor-keys": "8.24.1",
+                "@typescript-eslint/types": "8.27.0",
+                "@typescript-eslint/visitor-keys": "8.27.0",
                 "debug": "^4.3.4",
                 "fast-glob": "^3.3.2",
                 "is-glob": "^4.0.3",
@@ -5076,7 +5085,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <5.8.0"
+                "typescript": ">=4.8.4 <5.9.0"
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
@@ -5119,16 +5128,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.24.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.24.1.tgz",
-            "integrity": "sha512-OOcg3PMMQx9EXspId5iktsI3eMaXVwlhC8BvNnX6B5w9a4dVgpkQZuU8Hy67TolKcl+iFWq0XX+jbDGN4xWxjQ==",
+            "version": "8.27.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.27.0.tgz",
+            "integrity": "sha512-njkodcwH1yvmo31YWgRHNb/x1Xhhq4/m81PhtvmRngD8iHPehxffz1SNCO+kwaePhATC+kOa/ggmvPoPza5i0Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
-                "@typescript-eslint/scope-manager": "8.24.1",
-                "@typescript-eslint/types": "8.24.1",
-                "@typescript-eslint/typescript-estree": "8.24.1"
+                "@typescript-eslint/scope-manager": "8.27.0",
+                "@typescript-eslint/types": "8.27.0",
+                "@typescript-eslint/typescript-estree": "8.27.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5139,17 +5148,17 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.8.0"
+                "typescript": ">=4.8.4 <5.9.0"
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.24.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.24.1.tgz",
-            "integrity": "sha512-EwVHlp5l+2vp8CoqJm9KikPZgi3gbdZAtabKT9KPShGeOcJhsv4Zdo3oc8T8I0uKEmYoU4ItyxbptjF08enaxg==",
+            "version": "8.27.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.27.0.tgz",
+            "integrity": "sha512-WsXQwMkILJvffP6z4U3FYJPlbf/j07HIxmDjZpbNvBJkMfvwXj5ACRkkHwBDvLBbDbtX5TdU64/rcvKJ/vuInQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.24.1",
+                "@typescript-eslint/types": "8.27.0",
                 "eslint-visitor-keys": "^4.2.0"
             },
             "engines": {
@@ -5169,16 +5178,136 @@
                 "fast-diff": "1.3.0"
             }
         },
-        "node_modules/@vitest/expect": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.0.5.tgz",
-            "integrity": "sha512-nNIOqupgZ4v5jWuQx2DSlHLEs7Q4Oh/7AYwNyE+k0UQzG7tSmjPXShUikn1mpNGzYEN2jJbTvLejwShMitovBA==",
+        "node_modules/@vitest/coverage-v8": {
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.0.9.tgz",
+            "integrity": "sha512-15OACZcBtQ34keIEn19JYTVuMFTlFrClclwWjHo/IRPg/8ELpkgNTl0o7WLP9WO9XGH6+tip9CPYtEOrIDJvBA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/spy": "3.0.5",
-                "@vitest/utils": "3.0.5",
-                "chai": "^5.1.2",
+                "@ampproject/remapping": "^2.3.0",
+                "@bcoe/v8-coverage": "^1.0.2",
+                "debug": "^4.4.0",
+                "istanbul-lib-coverage": "^3.2.2",
+                "istanbul-lib-report": "^3.0.1",
+                "istanbul-lib-source-maps": "^5.0.6",
+                "istanbul-reports": "^3.1.7",
+                "magic-string": "^0.30.17",
+                "magicast": "^0.3.5",
+                "std-env": "^3.8.0",
+                "test-exclude": "^7.0.1",
+                "tinyrainbow": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@vitest/browser": "3.0.9",
+                "vitest": "3.0.9"
+            },
+            "peerDependenciesMeta": {
+                "@vitest/browser": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/coverage-v8/node_modules/@bcoe/v8-coverage": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+            "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@vitest/coverage-v8/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/@vitest/coverage-v8/node_modules/glob": {
+            "version": "10.4.5",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+            "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@vitest/coverage-v8/node_modules/istanbul-lib-source-maps": {
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+            "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@jridgewell/trace-mapping": "^0.3.23",
+                "debug": "^4.1.1",
+                "istanbul-lib-coverage": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@vitest/coverage-v8/node_modules/minimatch": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@vitest/coverage-v8/node_modules/test-exclude": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
+            "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@istanbuljs/schema": "^0.1.2",
+                "glob": "^10.4.1",
+                "minimatch": "^9.0.4"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@vitest/expect": {
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.0.9.tgz",
+            "integrity": "sha512-5eCqRItYgIML7NNVgJj6TVCmdzE7ZVgJhruW0ziSQV4V7PvLkDL1bBkBdcTs/VuIz0IxPb5da1IDSqc1TR9eig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "3.0.9",
+                "@vitest/utils": "3.0.9",
+                "chai": "^5.2.0",
                 "tinyrainbow": "^2.0.0"
             },
             "funding": {
@@ -5186,13 +5315,13 @@
             }
         },
         "node_modules/@vitest/mocker": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.0.5.tgz",
-            "integrity": "sha512-CLPNBFBIE7x6aEGbIjaQAX03ZZlBMaWwAjBdMkIf/cAn6xzLTiM3zYqO/WAbieEjsAZir6tO71mzeHZoodThvw==",
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.0.9.tgz",
+            "integrity": "sha512-ryERPIBOnvevAkTq+L1lD+DTFBRcjueL9lOUfXsLfwP92h4e+Heb+PjiqS3/OURWPtywfafK0kj++yDFjWUmrA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/spy": "3.0.5",
+                "@vitest/spy": "3.0.9",
                 "estree-walker": "^3.0.3",
                 "magic-string": "^0.30.17"
             },
@@ -5213,9 +5342,9 @@
             }
         },
         "node_modules/@vitest/pretty-format": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.5.tgz",
-            "integrity": "sha512-CjUtdmpOcm4RVtB+up8r2vVDLR16Mgm/bYdkGFe3Yj/scRfCpbSi2W/BDSDcFK7ohw8UXvjMbOp9H4fByd/cOA==",
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.9.tgz",
+            "integrity": "sha512-OW9F8t2J3AwFEwENg3yMyKWweF7oRJlMyHOMIhO5F3n0+cgQAJZBjNgrF8dLwFTEXl5jUqBLXd9QyyKv8zEcmA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5226,38 +5355,38 @@
             }
         },
         "node_modules/@vitest/runner": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.0.5.tgz",
-            "integrity": "sha512-BAiZFityFexZQi2yN4OX3OkJC6scwRo8EhRB0Z5HIGGgd2q+Nq29LgHU/+ovCtd0fOfXj5ZI6pwdlUmC5bpi8A==",
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.0.9.tgz",
+            "integrity": "sha512-NX9oUXgF9HPfJSwl8tUZCMP1oGx2+Sf+ru6d05QjzQz4OwWg0psEzwY6VexP2tTHWdOkhKHUIZH+fS6nA7jfOw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/utils": "3.0.5",
-                "pathe": "^2.0.2"
+                "@vitest/utils": "3.0.9",
+                "pathe": "^2.0.3"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vitest/snapshot": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.0.5.tgz",
-            "integrity": "sha512-GJPZYcd7v8QNUJ7vRvLDmRwl+a1fGg4T/54lZXe+UOGy47F9yUfE18hRCtXL5aHN/AONu29NGzIXSVFh9K0feA==",
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.0.9.tgz",
+            "integrity": "sha512-AiLUiuZ0FuA+/8i19mTYd+re5jqjEc2jZbgJ2up0VY0Ddyyxg/uUtBDpIFAy4uzKaQxOW8gMgBdAJJ2ydhu39A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "3.0.5",
+                "@vitest/pretty-format": "3.0.9",
                 "magic-string": "^0.30.17",
-                "pathe": "^2.0.2"
+                "pathe": "^2.0.3"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vitest/spy": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.0.5.tgz",
-            "integrity": "sha512-5fOzHj0WbUNqPK6blI/8VzZdkBlQLnT25knX0r4dbZI9qoZDf3qAdjoMmDcLG5A83W6oUUFJgUd0EYBc2P5xqg==",
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.0.9.tgz",
+            "integrity": "sha512-/CcK2UDl0aQ2wtkp3YVWldrpLRNCfVcIOFGlVGKO4R5eajsH393Z1yiXLVQ7vWsj26JOEjeZI0x5sm5P4OGUNQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5268,14 +5397,14 @@
             }
         },
         "node_modules/@vitest/utils": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.0.5.tgz",
-            "integrity": "sha512-N9AX0NUoUtVwKwy21JtwzaqR5L5R5A99GAbrHfCCXK1lp593i/3AZAXhSP43wRQuxYsflrdzEfXZFo1reR1Nkg==",
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.0.9.tgz",
+            "integrity": "sha512-ilHM5fHhZ89MCp5aAaM9uhfl1c2JdxVxl3McqsdVyVNN6JffnEen8UMCdRTzOhGXNQGo5GNL9QugHrz727Wnng==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "3.0.5",
-                "loupe": "^3.1.2",
+                "@vitest/pretty-format": "3.0.9",
+                "loupe": "^3.1.3",
                 "tinyrainbow": "^2.0.0"
             },
             "funding": {
@@ -5300,7 +5429,6 @@
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
@@ -5324,6 +5452,8 @@
             "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">= 14"
             }
@@ -5334,7 +5464,6 @@
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -5463,7 +5592,9 @@
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/autoprefixer": {
             "version": "10.4.20",
@@ -5942,9 +6073,9 @@
             "license": "CC-BY-4.0"
         },
         "node_modules/chai": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/chai/-/chai-5.1.2.tgz",
-            "integrity": "sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
+            "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6127,6 +6258,8 @@
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "delayed-stream": "~1.0.0"
             },
@@ -6260,6 +6393,8 @@
             "integrity": "sha512-9+vem03dMXG7gDmZ62uqmRiMRNtinIZ9ZyuF6BdxzfOD+FdN5hretzynkn0ReS2DO2GSw76RWHs0UmJPI2zUjw==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@asamuzakjp/css-color": "^2.8.2",
                 "rrweb-cssom": "^0.8.0"
@@ -6304,6 +6439,8 @@
             "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "whatwg-mimetype": "^4.0.0",
                 "whatwg-url": "^14.0.0"
@@ -6318,6 +6455,8 @@
             "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "punycode": "^2.3.1"
             },
@@ -6331,6 +6470,8 @@
             "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -6341,6 +6482,8 @@
             "integrity": "sha512-jlf/foYIKywAt3x/XWKZ/3rz8OSJPiWktjmk891alJUEjiVxKX9LEO92qH3hv4aJ0mN3MWPvGMCy8jQi95xK4w==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "tr46": "^5.0.0",
                 "webidl-conversions": "^7.0.0"
@@ -6384,7 +6527,9 @@
             "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
             "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/dedent": {
             "version": "1.5.3",
@@ -6416,8 +6561,7 @@
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/deepmerge": {
             "version": "4.3.1",
@@ -6434,6 +6578,8 @@
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -6564,6 +6710,8 @@
             "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.12"
             },
@@ -6648,19 +6796,19 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.21.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.21.0.tgz",
-            "integrity": "sha512-KjeihdFqTPhOMXTt7StsDxriV4n66ueuF/jfPNC3j/lduHwr/ijDwJMsF+wyMJethgiKi5wniIE243vi07d3pg==",
+            "version": "9.22.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.22.0.tgz",
+            "integrity": "sha512-9V/QURhsRN40xuHXWjV64yvrzMjcz7ZyNoF2jJFmy9j/SLk0u1OLSZgXi28MrXjymnjEGSR80WCdab3RGMDveQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.12.1",
                 "@eslint/config-array": "^0.19.2",
+                "@eslint/config-helpers": "^0.1.0",
                 "@eslint/core": "^0.12.0",
                 "@eslint/eslintrc": "^3.3.0",
-                "@eslint/js": "9.21.0",
+                "@eslint/js": "9.22.0",
                 "@eslint/plugin-kit": "^0.2.7",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
@@ -6672,7 +6820,7 @@
                 "cross-spawn": "^7.0.6",
                 "debug": "^4.3.2",
                 "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^8.2.0",
+                "eslint-scope": "^8.3.0",
                 "eslint-visitor-keys": "^4.2.0",
                 "espree": "^10.3.0",
                 "esquery": "^1.5.0",
@@ -6709,12 +6857,11 @@
             }
         },
         "node_modules/eslint-scope": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.2.0.tgz",
-            "integrity": "sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==",
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
+            "integrity": "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^5.2.0"
@@ -6745,7 +6892,6 @@
             "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -6759,7 +6905,6 @@
             "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "locate-path": "^6.0.0",
                 "path-exists": "^4.0.0"
@@ -6777,7 +6922,6 @@
             "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "is-glob": "^4.0.3"
             },
@@ -6791,7 +6935,6 @@
             "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "p-locate": "^5.0.0"
             },
@@ -6808,7 +6951,6 @@
             "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "p-limit": "^3.0.2"
             },
@@ -6825,7 +6967,6 @@
             "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "acorn": "^8.14.0",
                 "acorn-jsx": "^5.3.2",
@@ -6858,7 +6999,6 @@
             "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
             "dev": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "dependencies": {
                 "estraverse": "^5.1.0"
             },
@@ -6872,7 +7012,6 @@
             "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "estraverse": "^5.2.0"
             },
@@ -6886,7 +7025,6 @@
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -6985,8 +7123,7 @@
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/fast-diff": {
             "version": "1.3.0",
@@ -7022,8 +7159,7 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/fastparse": {
             "version": "1.1.2",
@@ -7057,7 +7193,6 @@
             "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "flat-cache": "^4.0.0"
             },
@@ -7258,7 +7393,6 @@
             "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "flatted": "^3.2.9",
                 "keyv": "^4.5.4"
@@ -7272,8 +7406,7 @@
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
             "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
             "dev": true,
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
         },
         "node_modules/foreground-child": {
             "version": "3.3.0",
@@ -7309,6 +7442,8 @@
             "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
@@ -7537,6 +7672,8 @@
             "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "whatwg-encoding": "^3.1.1"
             },
@@ -7557,6 +7694,8 @@
             "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "agent-base": "^7.1.0",
                 "debug": "^4.3.4"
@@ -7571,6 +7710,8 @@
             "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "agent-base": "^7.1.2",
                 "debug": "4"
@@ -7619,6 +7760,8 @@
             "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
@@ -7674,7 +7817,6 @@
             "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "parent-module": "^1.0.0",
                 "resolve-from": "^4.0.0"
@@ -7692,7 +7834,6 @@
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -7856,7 +7997,9 @@
             "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
             "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/is-reference": {
             "version": "3.0.3",
@@ -8679,6 +8822,8 @@
             "integrity": "sha512-BZYDGVAIriBWTpIxYzrXjv3E/4u8+/pSG5bQdIYCbNCGOvsPkDQfTVLAIXAf9ETdCpduCVTkDe2NNZ8NIwUVzw==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "cssstyle": "^4.2.1",
                 "data-urls": "^5.0.0",
@@ -8720,6 +8865,8 @@
             "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "punycode": "^2.3.1"
             },
@@ -8733,6 +8880,8 @@
             "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -8743,6 +8892,8 @@
             "integrity": "sha512-jlf/foYIKywAt3x/XWKZ/3rz8OSJPiWktjmk891alJUEjiVxKX9LEO92qH3hv4aJ0mN3MWPvGMCy8jQi95xK4w==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "tr46": "^5.0.0",
                 "webidl-conversions": "^7.0.0"
@@ -8769,8 +8920,7 @@
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
             "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
@@ -8784,16 +8934,14 @@
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/json-text-sequence": {
             "version": "0.1.1",
@@ -8823,7 +8971,6 @@
             "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "json-buffer": "3.0.1"
             }
@@ -8864,7 +9011,6 @@
             "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1",
                 "type-check": "~0.4.0"
@@ -9157,8 +9303,7 @@
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/log-symbols": {
             "version": "4.1.0",
@@ -9201,6 +9346,18 @@
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.0"
+            }
+        },
+        "node_modules/magicast": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+            "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.25.4",
+                "@babel/types": "^7.25.4",
+                "source-map-js": "^1.2.0"
             }
         },
         "node_modules/make-dir": {
@@ -9290,6 +9447,8 @@
             "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">= 0.6"
             }
@@ -9300,6 +9459,8 @@
             "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "mime-db": "1.52.0"
             },
@@ -9655,7 +9816,9 @@
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.16.tgz",
             "integrity": "sha512-F1I/bimDpj3ncaNDhfyMWuFqmQDBwDB0Fogc2qpL3BWvkQteFD/8BzWuIRl83rq0DXfm8SGt/HFhLXZyljTXcQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/object-assign": {
             "version": "4.1.1",
@@ -9707,7 +9870,6 @@
             "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
@@ -9787,7 +9949,6 @@
             "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "callsites": "^3.0.0"
             },
@@ -9820,6 +9981,8 @@
             "integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "entities": "^4.5.0"
             },
@@ -9885,9 +10048,9 @@
             "license": "ISC"
         },
         "node_modules/pathe": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.2.tgz",
-            "integrity": "sha512-15Ztpk+nov8DR524R4BF7uEuzESgzUEAV4Ah7CUMNGXdE5ELuvxElxGXndBl32vMSsWa1jpNf22Z+Er3sKwq+w==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
             "dev": true,
             "license": "MIT"
         },
@@ -10111,7 +10274,6 @@
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">= 0.8.0"
             }
@@ -10494,7 +10656,9 @@
             "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
             "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/run-parallel": {
             "version": "1.2.0",
@@ -10544,7 +10708,9 @@
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/saxes": {
             "version": "6.0.0",
@@ -10552,6 +10718,8 @@
             "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
             "dev": true,
             "license": "ISC",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "xmlchars": "^2.2.0"
             },
@@ -10984,7 +11152,9 @@
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/tailwindcss": {
             "version": "4.0.6",
@@ -11087,6 +11257,8 @@
             "integrity": "sha512-6U2ti64/nppsDxQs9hw8ephA3nO6nSQvVVfxwRw8wLQPFtLI1cFI1a1eP22g+LUP+1TA2pKKjUTwWB+K2coqmQ==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "tldts-core": "^6.1.76"
             },
@@ -11099,7 +11271,9 @@
             "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.76.tgz",
             "integrity": "sha512-uzhJ02RaMzgQR3yPoeE65DrcHI6LoM4saUqXOt/b5hmb3+mc4YWpdSeAQqVqRUlQ14q8ZuLRWyBR1ictK1dzzg==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/tmpl": {
             "version": "1.0.5",
@@ -11126,6 +11300,8 @@
             "integrity": "sha512-rvZUv+7MoBYTiDmFPBrhL7Ujx9Sk+q9wwm22x8c8T5IJaR+Wsyc7TNxbVxo84kZoRJZZMazowFLqpankBEQrGg==",
             "dev": true,
             "license": "BSD-3-Clause",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "tldts": "^6.1.32"
             },
@@ -11141,9 +11317,9 @@
             "license": "MIT"
         },
         "node_modules/ts-api-utils": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.1.tgz",
-            "integrity": "sha512-dnlgjFSVetynI8nzgJ+qF62efpglpWRk8isUEWZGWlJYySCTD6aKvbUDu+zbPeDakk3bg5H4XpitHukgfL1m9w==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+            "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -11278,7 +11454,6 @@
             "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1"
             },
@@ -11310,9 +11485,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.7.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-            "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+            "version": "5.8.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+            "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
@@ -11323,15 +11498,15 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.24.1",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.24.1.tgz",
-            "integrity": "sha512-cw3rEdzDqBs70TIcb0Gdzbt6h11BSs2pS0yaq7hDWDBtCCSei1pPSUXE9qUdQ/Wm9NgFg8mKtMt1b8fTHIl1jA==",
+            "version": "8.27.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.27.0.tgz",
+            "integrity": "sha512-ZZ/8+Y0rRUMuW1gJaPtLWe4ryHbsPLzzibk5Sq+IFa2aOH1Vo0gPr1fbA6pOnzBke7zC2Da4w8AyCgxKXo3lqA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.24.1",
-                "@typescript-eslint/parser": "8.24.1",
-                "@typescript-eslint/utils": "8.24.1"
+                "@typescript-eslint/eslint-plugin": "8.27.0",
+                "@typescript-eslint/parser": "8.27.0",
+                "@typescript-eslint/utils": "8.27.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -11342,7 +11517,7 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.8.0"
+                "typescript": ">=4.8.4 <5.9.0"
             }
         },
         "node_modules/undici-types": {
@@ -11431,7 +11606,6 @@
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "punycode": "^2.1.0"
             }
@@ -11549,16 +11723,16 @@
             }
         },
         "node_modules/vite-node": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.0.5.tgz",
-            "integrity": "sha512-02JEJl7SbtwSDJdYS537nU6l+ktdvcREfLksk/NDAqtdKWGqHl+joXzEubHROmS3E6pip+Xgu2tFezMu75jH7A==",
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.0.9.tgz",
+            "integrity": "sha512-w3Gdx7jDcuT9cNn9jExXgOyKmf5UOTb6WMHz8LGAm54eS1Elf5OuBhCxl6zJxGhEeIkgsE1WbHuoL0mj/UXqXg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "cac": "^6.7.14",
                 "debug": "^4.4.0",
                 "es-module-lexer": "^1.6.0",
-                "pathe": "^2.0.2",
+                "pathe": "^2.0.3",
                 "vite": "^5.0.0 || ^6.0.0"
             },
             "bin": {
@@ -11619,31 +11793,31 @@
             }
         },
         "node_modules/vitest": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.0.5.tgz",
-            "integrity": "sha512-4dof+HvqONw9bvsYxtkfUp2uHsTN9bV2CZIi1pWgoFpL1Lld8LA1ka9q/ONSsoScAKG7NVGf2stJTI7XRkXb2Q==",
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.0.9.tgz",
+            "integrity": "sha512-BbcFDqNyBlfSpATmTtXOAOj71RNKDDvjBM/uPfnxxVGrG+FSH2RQIwgeEngTaTkuU/h0ScFvf+tRcKfYXzBybQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/expect": "3.0.5",
-                "@vitest/mocker": "3.0.5",
-                "@vitest/pretty-format": "^3.0.5",
-                "@vitest/runner": "3.0.5",
-                "@vitest/snapshot": "3.0.5",
-                "@vitest/spy": "3.0.5",
-                "@vitest/utils": "3.0.5",
-                "chai": "^5.1.2",
+                "@vitest/expect": "3.0.9",
+                "@vitest/mocker": "3.0.9",
+                "@vitest/pretty-format": "^3.0.9",
+                "@vitest/runner": "3.0.9",
+                "@vitest/snapshot": "3.0.9",
+                "@vitest/spy": "3.0.9",
+                "@vitest/utils": "3.0.9",
+                "chai": "^5.2.0",
                 "debug": "^4.4.0",
                 "expect-type": "^1.1.0",
                 "magic-string": "^0.30.17",
-                "pathe": "^2.0.2",
+                "pathe": "^2.0.3",
                 "std-env": "^3.8.0",
                 "tinybench": "^2.9.0",
                 "tinyexec": "^0.3.2",
                 "tinypool": "^1.0.2",
                 "tinyrainbow": "^2.0.0",
                 "vite": "^5.0.0 || ^6.0.0",
-                "vite-node": "3.0.5",
+                "vite-node": "3.0.9",
                 "why-is-node-running": "^2.3.0"
             },
             "bin": {
@@ -11659,8 +11833,8 @@
                 "@edge-runtime/vm": "*",
                 "@types/debug": "^4.1.12",
                 "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-                "@vitest/browser": "3.0.5",
-                "@vitest/ui": "3.0.5",
+                "@vitest/browser": "3.0.9",
+                "@vitest/ui": "3.0.9",
                 "happy-dom": "*",
                 "jsdom": "*"
             },
@@ -11694,6 +11868,8 @@
             "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "xml-name-validator": "^5.0.0"
             },
@@ -11724,6 +11900,8 @@
             "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "iconv-lite": "0.6.3"
             },
@@ -11744,6 +11922,8 @@
             "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -11797,7 +11977,6 @@
             "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -11872,6 +12051,8 @@
             "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -11894,6 +12075,8 @@
             "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
             "dev": true,
             "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -11903,7 +12086,9 @@
             "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
             "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/y18n": {
             "version": "5.0.8",
@@ -12017,36 +12202,39 @@
         },
         "sdk/ic_vetkd_sdk_encrypted_maps": {
             "version": "0.1.0",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@dfinity/principal": "^2.3.0",
-                "ic-vetkd-cdk-utils": "file:../../cdk/utils/pkg",
                 "idb-keyval": "^6.2.1"
             },
             "devDependencies": {
-                "typescript": "^5.7.3"
+                "@eslint/js": "^9.22.0",
+                "eslint": "^9.22.0",
+                "typescript": "^5.8.2",
+                "typescript-eslint": "^8.27.0"
+            },
+            "peerDependencies": {
+                "ic-vetkd-cdk-utils": "^0.1.0"
             }
         },
         "sdk/ic_vetkd_sdk_encrypted_maps_example": {
             "version": "0.1.0",
             "dependencies": {
                 "@dfinity/agent": "^2.3.0",
-                "idb-keyval": "^6.2.1",
+                "@dfinity/candid": "^2.3.0",
+                "@dfinity/principal": "^2.3.0",
                 "typescript": "^5.7.3",
                 "vite-plugin-top-level-await": "^1.4.4",
                 "vite-plugin-wasm": "^3.4.1"
             },
             "devDependencies": {
-                "@babel/preset-env": "7.26.0",
-                "@babel/preset-typescript": "^7.26.0",
                 "@dfinity/identity": "^2.2.0",
-                "@jest/globals": "^29.7.0",
-                "@types/jest": "^29.5.14",
+                "@eslint/js": "^9.22.0",
+                "@vitest/coverage-v8": "^3.0.5",
+                "eslint": "^9.22",
                 "fake-indexeddb": "^6.0.0",
                 "isomorphic-fetch": "3.0.0",
-                "jest": "^29.7.0",
-                "jsdom": "^26.0.0",
-                "ts-jest": "^29.2.5",
-                "ts-node": "10.9.2",
+                "typescript-eslint": "8.27",
                 "vite": "^6.0.5",
                 "vitest": "^3.0.5"
             },
@@ -12061,7 +12249,10 @@
                 "@dfinity/principal": "^2.3.0"
             },
             "devDependencies": {
-                "typescript": "^5.7.3"
+                "@eslint/js": "^9.22.0",
+                "eslint": "^9.22.0",
+                "typescript": "^5.7.3",
+                "typescript-eslint": "8.27"
             },
             "peerDependencies": {
                 "ic-vetkd-cdk-utils": "^0.1.0"
@@ -12081,12 +12272,14 @@
                 "@babel/preset-typescript": "^7.26.0",
                 "@babel/register": "^7.25.9",
                 "@dfinity/identity": "^2.2.0",
+                "@eslint/js": "^9.22.0",
                 "@jest/globals": "^29.7.0",
                 "@types/chai": "^5.0.1",
                 "@types/isomorphic-fetch": "^0.0.39",
                 "@types/jest": "^29.5.14",
                 "@types/mocha": "^10.0.10",
                 "chai": "^5.1.2",
+                "eslint": "^9.22.0",
                 "happy-dom": "^17.0.0",
                 "isomorphic-fetch": "^3.0.0",
                 "jest": "^29.7.0",
@@ -12094,6 +12287,7 @@
                 "ts-jest": "^29.2.5",
                 "ts-node": "^10.9.2",
                 "typescript": "^5.7.3",
+                "typescript-eslint": "8.27",
                 "vite": "^6.0.11",
                 "vitest": "^3.0.5"
             },
@@ -12112,19 +12306,10 @@
                 "@babel/preset-typescript": "^7.26.0",
                 "@eslint/js": "^9.22.0",
                 "@jest/globals": "^29.7.0",
+                "eslint": "^9.22.0",
                 "jest": "^29.7.0",
                 "typescript": "^5.7.3",
-                "typescript-eslint": "8.24"
-            }
-        },
-        "sdk/ic_vetkd_sdk_utils/node_modules/@eslint/js": {
-            "version": "9.22.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.22.0.tgz",
-            "integrity": "sha512-vLFajx9o8d1/oL2ZkpMYbkLv8nDB6yaIwFNt7nI4+I80U/z03SxmfOMsLbvWr3p7C+Wnoh//aOu2pQW8cS0HCQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+                "typescript-eslint": "8.27"
             }
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10743,6 +10743,7 @@
             "version": "5.8.2",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
             "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+            "devOptional": true,
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
@@ -11445,7 +11446,6 @@
                 "@dfinity/agent": "^2.3.0",
                 "@dfinity/candid": "^2.3.0",
                 "@dfinity/principal": "^2.3.0",
-                "typescript": "^5.7.3",
                 "vite-plugin-top-level-await": "^1.4.4",
                 "vite-plugin-wasm": "^3.4.1"
             },
@@ -11456,6 +11456,7 @@
                 "eslint": "^9.22",
                 "fake-indexeddb": "^6.0.0",
                 "isomorphic-fetch": "3.0.0",
+                "typescript": "^5.7.3",
                 "typescript-eslint": "8.27",
                 "vite": "^6.0.5",
                 "vitest": "^3.0.5"

--- a/sdk/ic_vetkd_sdk_encrypted_maps_example/babel.config.js
+++ b/sdk/ic_vetkd_sdk_encrypted_maps_example/babel.config.js
@@ -1,7 +1,0 @@
-module.exports = {
-    presets: [
-      ['@babel/preset-env', {targets: {node: 'current'}}],
-      '@babel/preset-typescript',
-    ],
-  };
-  

--- a/sdk/ic_vetkd_sdk_encrypted_maps_example/package.json
+++ b/sdk/ic_vetkd_sdk_encrypted_maps_example/package.json
@@ -1,6 +1,7 @@
 {
     "name": "ic_vetkd_sdk_encrypted_maps_example",
     "version": "0.1.0",
+    "license": "Apache-2.0",
     "files": [
         "dist"
     ],

--- a/sdk/ic_vetkd_sdk_encrypted_maps_example/package.json
+++ b/sdk/ic_vetkd_sdk_encrypted_maps_example/package.json
@@ -12,25 +12,19 @@
     },
     "dependencies": {
         "@dfinity/agent": "^2.3.0",
-        "idb-keyval": "^6.2.1",
+        "@dfinity/candid": "^2.3.0",
+        "@dfinity/principal": "^2.3.0",
         "typescript": "^5.7.3",
         "vite-plugin-top-level-await": "^1.4.4",
         "vite-plugin-wasm": "^3.4.1"
     },
     "devDependencies": {
-        "@babel/preset-env": "7.26.0",
-        "@babel/preset-typescript": "^7.26.0",
         "@dfinity/identity": "^2.2.0",
         "@eslint/js": "^9.22.0",
-        "@jest/globals": "^29.7.0",
-        "@types/jest": "^29.5.14",
-        "fake-indexeddb": "^6.0.0",
+        "@vitest/coverage-v8": "^3.0.5",
         "eslint": "^9.22",
+        "fake-indexeddb": "^6.0.0",
         "isomorphic-fetch": "3.0.0",
-        "jest": "^29.7.0",
-        "jsdom": "^26.0.0",
-        "ts-jest": "^29.2.5",
-        "ts-node": "10.9.2",
         "typescript-eslint": "8.27",
         "vite": "^6.0.5",
         "vitest": "^3.0.5"
@@ -39,7 +33,6 @@
         "build": "tsc && vite build",
         "coverage": "vitest run --coverage",
         "test": "vitest",
-        "lint": "eslint",
-        "test:prod": "npm run lint && npm run test -- --no-cache"
+        "lint": "eslint"
     }
 }

--- a/sdk/ic_vetkd_sdk_encrypted_maps_example/package.json
+++ b/sdk/ic_vetkd_sdk_encrypted_maps_example/package.json
@@ -15,7 +15,6 @@
         "@dfinity/agent": "^2.3.0",
         "@dfinity/candid": "^2.3.0",
         "@dfinity/principal": "^2.3.0",
-        "typescript": "^5.7.3",
         "vite-plugin-top-level-await": "^1.4.4",
         "vite-plugin-wasm": "^3.4.1"
     },
@@ -27,6 +26,7 @@
         "fake-indexeddb": "^6.0.0",
         "isomorphic-fetch": "3.0.0",
         "typescript-eslint": "8.27",
+        "typescript": "^5.7.3",
         "vite": "^6.0.5",
         "vitest": "^3.0.5"
     },


### PR DESCRIPTION
## Before
```
sdk/ic_vetkd_sdk_encrypted_maps_example/ [main*] npx npm-check

idb-keyval                    😕  NOTUSED?  Still using idb-keyval?
                                           Depcheck did not find code similar to require('idb-keyval') or import from 'idb-keyval'.
                                           Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                           Use rc file options to remove unused check, but still monitor for outdated version:
                                               .npmcheckrc {"depcheck": {"ignoreMatches": ["idb-keyval"]}}
                                           Use --skip-unused to skip this check.
                                           To remove this package: npm uninstall idb-keyval --save

vite-plugin-top-level-await   😍  UPDATE!   Your local install is out of date. https://github.com/Menci/vite-plugin-top-level-await#readme
                                           npm install vite-plugin-top-level-await@1.5.0 --save to go from 1.4.4 to 1.5.0

@babel/preset-env             😎  PATCH UP  Patch update available. https://babel.dev/docs/en/next/babel-preset-env
                                           npm install @babel/preset-env@7.26.9 --save-dev to go from 7.26.0 to 7.26.9

@jest/globals                 😕  NOTUSED?  Still using @jest/globals?
                                           Depcheck did not find code similar to require('@jest/globals') or import from '@jest/globals'.
                                           Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                           Use rc file options to remove unused check, but still monitor for outdated version:
                                               .npmcheckrc {"depcheck": {"ignoreMatches": ["@jest/globals"]}}
                                           Use --skip-unused to skip this check.
                                           To remove this package: npm uninstall @jest/globals --save-dev

jest                          😕  NOTUSED?  Still using jest?
                                           Depcheck did not find code similar to require('jest') or import from 'jest'.
                                           Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                           Use rc file options to remove unused check, but still monitor for outdated version:
                                               .npmcheckrc {"depcheck": {"ignoreMatches": ["jest"]}}
                                           Use --skip-unused to skip this check.
                                           To remove this package: npm uninstall jest --save-dev

ts-jest                       😍  UPDATE!   Your local install is out of date. https://kulshekhar.github.io/ts-jest
                                           npm install ts-jest@29.2.6 --save-dev to go from 29.2.5 to 29.2.6
                              😕  NOTUSED?  Still using ts-jest?
                                           Depcheck did not find code similar to require('ts-jest') or import from 'ts-jest'.
                                           Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                           Use rc file options to remove unused check, but still monitor for outdated version:
                                               .npmcheckrc {"depcheck": {"ignoreMatches": ["ts-jest"]}}
                                           Use --skip-unused to skip this check.
                                           To remove this package: npm uninstall ts-jest --save-dev

ts-node                       😕  NOTUSED?  Still using ts-node?
                                           Depcheck did not find code similar to require('ts-node') or import from 'ts-node'.
                                           Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                           Use rc file options to remove unused check, but still monitor for outdated version:
                                               .npmcheckrc {"depcheck": {"ignoreMatches": ["ts-node"]}}
                                           Use --skip-unused to skip this check.
                                           To remove this package: npm uninstall ts-node --save-dev

vite                          😍  UPDATE!   Your local install is out of date. https://vite.dev
                                           npm install vite@6.2.2 --save-dev to go from 6.1.0 to 6.2.2

vitest                        😍  UPDATE!   Your local install is out of date. https://github.com/vitest-dev/vitest#readme
                                           npm install vitest@3.0.9 --save-dev to go from 3.0.5 to 3.0.9

@dfinity/principal            😟  PKG ERR!  Not in the package.json. Found in: /src/index.ts, /src/declarations/encrypted_maps_example/encrypted_maps_example.did.d.ts, /src/declarations/encrypted_maps_example/index.d.ts

@dfinity/candid               😟  PKG ERR!  Not in the package.json. Found in: /src/declarations/encrypted_maps_example/encrypted_maps_example.did.d.ts, /src/declarations/encrypted_maps_example/index.d.ts

Use npm-check -u for interactive update.
```

## After
```
sdk/ic_vetkd_sdk_encrypted_maps_example/ [franzstefan/fix-enc-maps-example-deps] npx npm-check                      

vite-plugin-top-level-await   😍  UPDATE!   Your local install is out of date. https://github.com/Menci/vite-plugin-top-level-await#readme
                                           npm install vite-plugin-top-level-await@1.5.0 --save to go from 1.4.4 to 1.5.0

@vitest/coverage-v8           😕  NOTUSED?  Still using @vitest/coverage-v8?
                                           Depcheck did not find code similar to require('@vitest/coverage-v8') or import from '@vitest/coverage-v8'.
                                           Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                           Use rc file options to remove unused check, but still monitor for outdated version:
                                               .npmcheckrc {"depcheck": {"ignoreMatches": ["@vitest/coverage-v8"]}}
                                           Use --skip-unused to skip this check.
                                           To remove this package: npm uninstall @vitest/coverage-v8 --save-dev

vite                          😍  UPDATE!   Your local install is out of date. https://vite.dev
                                           npm install vite@6.2.2 --save-dev to go from 6.1.0 to 6.2.2

Use npm-check -u for interactive update.
```
and
```
sdk/ic_vetkd_sdk_encrypted_maps_example/ [franzstefan/fix-enc-maps-example-deps] npx depcheck               
Unused devDependencies
* @vitest/coverage-v8
```

## Notes
The reported unused `@vitest/coverage-v8` is a false positive, because it is used by the following script in `package.json`:
```
"coverage": "vitest run --coverage",
```