### PR TITLE
chore: CRP-2724 fix dependencies in password manager example

### DIFF
--- a/examples/password_manager/frontend/package.json
+++ b/examples/password_manager/frontend/package.json
@@ -8,19 +8,23 @@
     "build:deps": "cd ../../../sdk/ic_vetkd_sdk_encrypted_maps_example && npm i && npm run build",
     "preview": "vite preview"
   },
+  "peerDependencies": {
+    "ic_vetkd_sdk_encrypted_maps": "^0.1.0"
+  },
   "devDependencies": {
     "@rollup/plugin-typescript": "^12.1.2",
     "daisyui": "^4.12.23",
     "svelte": "^4.2.19",
-    "tslib": "^2.8.1",
     "vite": "^5.4.14",
     "vite-plugin-environment": "^1.1.3",
     "vite-plugin-top-level-await": "^1.4.4",
     "vite-plugin-wasm": "^3.4.1"
   },
   "dependencies": {
+    "@dfinity/agent": "^2.3.0",
     "@dfinity/auth-client": "^2.3.0",
     "@dfinity/candid": "^2.3.0",
+    "@dfinity/identity": "^2.3.0",
     "@dfinity/principal": "^2.3.0",
     "@sveltejs/vite-plugin-svelte": "^3.0.2",
     "@tailwindcss/line-clamp": "^0.4.4",

--- a/examples/password_manager/frontend/package.json
+++ b/examples/password_manager/frontend/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview"
   },
   "peerDependencies": {
-    "ic_vetkd_sdk_encrypted_maps": "^0.1.0"
+    "ic_vetkd_sdk_encrypted_maps": "^0.1.0",
+    "ic_vetkd_sdk_encrypted_maps_example": "^0.1.0"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^12.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,10 @@
         "examples/password_manager/frontend": {
             "version": "0.1.0",
             "dependencies": {
+                "@dfinity/agent": "^2.3.0",
                 "@dfinity/auth-client": "^2.3.0",
                 "@dfinity/candid": "^2.3.0",
+                "@dfinity/identity": "^2.3.0",
                 "@dfinity/principal": "^2.3.0",
                 "@sveltejs/vite-plugin-svelte": "^3.0.2",
                 "@tailwindcss/line-clamp": "^0.4.4",
@@ -35,7 +37,6 @@
                 "@rollup/plugin-typescript": "^12.1.2",
                 "daisyui": "^4.12.23",
                 "svelte": "^4.2.19",
-                "tslib": "^2.8.1",
                 "vite": "^5.4.14",
                 "vite-plugin-environment": "^1.1.3",
                 "vite-plugin-top-level-await": "^1.4.4",
@@ -10779,7 +10780,9 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "dev": true,
-            "license": "0BSD"
+            "license": "0BSD",
+            "optional": true,
+            "peer": true
         },
         "node_modules/type-check": {
             "version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,8 @@
                 "vite-plugin-wasm": "^3.4.1"
             },
             "peerDependencies": {
-                "ic_vetkd_sdk_encrypted_maps": "^0.1.0"
+                "ic_vetkd_sdk_encrypted_maps": "^0.1.0",
+                "ic_vetkd_sdk_encrypted_maps_example": "^0.1.0"
             }
         },
         "examples/password_manager/frontend/node_modules/@esbuild/aix-ppc64": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,9 @@
                 "vite-plugin-environment": "^1.1.3",
                 "vite-plugin-top-level-await": "^1.4.4",
                 "vite-plugin-wasm": "^3.4.1"
+            },
+            "peerDependencies": {
+                "ic_vetkd_sdk_encrypted_maps": "^0.1.0"
             }
         },
         "examples/password_manager/frontend/node_modules/@esbuild/aix-ppc64": {


### PR DESCRIPTION
Cleanup dependencies in password manager example. There are a few dependencies that npm-check reports as unused, but they all seem used via svelte.

## Before
```
examples/password_manager/frontend/ [main] npx npm-check              

@sveltejs/vite-plugin-svelte   😎  MAJOR UP  Major update available. https://github.com/sveltejs/vite-plugin-svelte#readme
                                            npm install @sveltejs/vite-plugin-svelte@5.0.3 --save to go from 3.0.2 to 5.0.3

@tailwindcss/postcss           😍  UPDATE!   Your local install is out of date. https://tailwindcss.com
                                            npm install @tailwindcss/postcss@4.0.15 --save to go from 4.0.6 to 4.0.15
                               😕  NOTUSED?  Still using @tailwindcss/postcss?
                                            Depcheck did not find code similar to require('@tailwindcss/postcss') or import from '@tailwindcss/postcss'.
                                            Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                            Use rc file options to remove unused check, but still monitor for outdated version:
                                                .npmcheckrc {"depcheck": {"ignoreMatches": ["@tailwindcss/postcss"]}}
                                            Use --skip-unused to skip this check.
                                            To remove this package: npm uninstall @tailwindcss/postcss --save

@tailwindcss/vite              😍  UPDATE!   Your local install is out of date. https://tailwindcss.com
                                            npm install @tailwindcss/vite@4.0.15 --save to go from 4.0.6 to 4.0.15
                               😕  NOTUSED?  Still using @tailwindcss/vite?
                                            Depcheck did not find code similar to require('@tailwindcss/vite') or import from '@tailwindcss/vite'.
                                            Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                            Use rc file options to remove unused check, but still monitor for outdated version:
                                                .npmcheckrc {"depcheck": {"ignoreMatches": ["@tailwindcss/vite"]}}
                                            Use --skip-unused to skip this check.
                                            To remove this package: npm uninstall @tailwindcss/vite --save

autoprefixer                   😍  UPDATE!   Your local install is out of date. https://github.com/postcss/autoprefixer#readme
                                            npm install autoprefixer@10.4.21 --save to go from 10.4.20 to 10.4.21

svelte-icons                   😕  NOTUSED?  Still using svelte-icons?
                                            Depcheck did not find code similar to require('svelte-icons') or import from 'svelte-icons'.
                                            Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                            Use rc file options to remove unused check, but still monitor for outdated version:
                                                .npmcheckrc {"depcheck": {"ignoreMatches": ["svelte-icons"]}}
                                            Use --skip-unused to skip this check.
                                            To remove this package: npm uninstall svelte-icons --save

tailwindcss                    😎  MAJOR UP  Major update available. https://tailwindcss.com
                                            npm install tailwindcss@4.0.15 --save to go from 3.4.17 to 4.0.15

typewriter-editor              😎  NEW VER!  NonSemver update available. https://github.com/typewriter-editor/typewriter#readme
                                            npm install typewriter-editor@0.12.9 --save to go from 0.9.4 to 0.12.9
                               😕  NOTUSED?  Still using typewriter-editor?
                                            Depcheck did not find code similar to require('typewriter-editor') or import from 'typewriter-editor'.
                                            Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                            Use rc file options to remove unused check, but still monitor for outdated version:
                                                .npmcheckrc {"depcheck": {"ignoreMatches": ["typewriter-editor"]}}
                                            Use --skip-unused to skip this check.
                                            To remove this package: npm uninstall typewriter-editor --save

daisyui                        😎  MAJOR UP  Major update available. https://daisyui.com
                                            npm install daisyui@5.0.9 --save-dev to go from 4.12.23 to 5.0.9

svelte                         😎  MAJOR UP  Major update available. https://svelte.dev
                                            npm install svelte@5.24.1 --save-dev to go from 4.2.19 to 5.24.1

vite                           😎  MAJOR UP  Major update available. https://vite.dev
                                            npm install vite@6.2.2 --save-dev to go from 5.4.14 to 6.2.2

vite-plugin-top-level-await    😍  UPDATE!   Your local install is out of date. https://github.com/Menci/vite-plugin-top-level-await#readme
                                            npm install vite-plugin-top-level-await@1.5.0 --save-dev to go from 1.4.4 to 1.5.0

@dfinity/identity              😟  PKG ERR!  Not in the package.json. Found in: /src/store/auth.ts

ic_vetkd_sdk_encrypted_maps    😟  MISSING!  Not installed.
                               😟  PKG ERR!  Not in the package.json. Found in: /src/store/auth.ts, /src/store/vaults.ts, /src/lib/encrypted_maps.ts, /src/lib/vault.ts
                               ⛔  NPM ERR!  Registry error Package `ic_vetkd_sdk_encrypted_maps` could not be found

@dfinity/agent                 😟  PKG ERR!  Not in the package.json. Found in: /src/lib/encrypted_maps.ts

Use npm-check -u for interactive update.
```

## After
```
examples/password_manager/frontend/ [franzstefan/fix-pw-mgr-deps] npx npm-check                            

@sveltejs/vite-plugin-svelte   😎  MAJOR UP  Major update available. https://github.com/sveltejs/vite-plugin-svelte#readme
                                            npm install @sveltejs/vite-plugin-svelte@5.0.3 --save to go from 3.0.2 to 5.0.3

@tailwindcss/postcss           😍  UPDATE!   Your local install is out of date. https://tailwindcss.com
                                            npm install @tailwindcss/postcss@4.0.15 --save to go from 4.0.6 to 4.0.15
                               😕  NOTUSED?  Still using @tailwindcss/postcss?
                                            Depcheck did not find code similar to require('@tailwindcss/postcss') or import from '@tailwindcss/postcss'.
                                            Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                            Use rc file options to remove unused check, but still monitor for outdated version:
                                                .npmcheckrc {"depcheck": {"ignoreMatches": ["@tailwindcss/postcss"]}}
                                            Use --skip-unused to skip this check.
                                            To remove this package: npm uninstall @tailwindcss/postcss --save

@tailwindcss/vite              😍  UPDATE!   Your local install is out of date. https://tailwindcss.com
                                            npm install @tailwindcss/vite@4.0.15 --save to go from 4.0.6 to 4.0.15
                               😕  NOTUSED?  Still using @tailwindcss/vite?
                                            Depcheck did not find code similar to require('@tailwindcss/vite') or import from '@tailwindcss/vite'.
                                            Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                            Use rc file options to remove unused check, but still monitor for outdated version:
                                                .npmcheckrc {"depcheck": {"ignoreMatches": ["@tailwindcss/vite"]}}
                                            Use --skip-unused to skip this check.
                                            To remove this package: npm uninstall @tailwindcss/vite --save

autoprefixer                   😍  UPDATE!   Your local install is out of date. https://github.com/postcss/autoprefixer#readme
                                            npm install autoprefixer@10.4.21 --save to go from 10.4.20 to 10.4.21

svelte-icons                   😕  NOTUSED?  Still using svelte-icons?
                                            Depcheck did not find code similar to require('svelte-icons') or import from 'svelte-icons'.
                                            Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                            Use rc file options to remove unused check, but still monitor for outdated version:
                                                .npmcheckrc {"depcheck": {"ignoreMatches": ["svelte-icons"]}}
                                            Use --skip-unused to skip this check.
                                            To remove this package: npm uninstall svelte-icons --save

tailwindcss                    😎  MAJOR UP  Major update available. https://tailwindcss.com
                                            npm install tailwindcss@4.0.15 --save to go from 3.4.17 to 4.0.15

typewriter-editor              😎  NEW VER!  NonSemver update available. https://github.com/typewriter-editor/typewriter#readme
                                            npm install typewriter-editor@0.12.9 --save to go from 0.9.4 to 0.12.9
                               😕  NOTUSED?  Still using typewriter-editor?
                                            Depcheck did not find code similar to require('typewriter-editor') or import from 'typewriter-editor'.
                                            Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                            Use rc file options to remove unused check, but still monitor for outdated version:
                                                .npmcheckrc {"depcheck": {"ignoreMatches": ["typewriter-editor"]}}
                                            Use --skip-unused to skip this check.
                                            To remove this package: npm uninstall typewriter-editor --save

daisyui                        😎  MAJOR UP  Major update available. https://daisyui.com
                                            npm install daisyui@5.0.9 --save-dev to go from 4.12.23 to 5.0.9

svelte                         😎  MAJOR UP  Major update available. https://svelte.dev
                                            npm install svelte@5.24.1 --save-dev to go from 4.2.19 to 5.24.1

vite                           😎  MAJOR UP  Major update available. https://vite.dev
                                            npm install vite@6.2.2 --save-dev to go from 5.4.14 to 6.2.2

vite-plugin-top-level-await    😍  UPDATE!   Your local install is out of date. https://github.com/Menci/vite-plugin-top-level-await#readme
                                            npm install vite-plugin-top-level-await@1.5.0 --save-dev to go from 1.4.4 to 1.5.0

Use npm-check -u for interactive update.
```