### PR TITLE
chore: CRP-2724 fix dependencies in password manager with metadata example

### DIFF
--- a/examples/password_manager_with_metadata/frontend/package-lock.json
+++ b/examples/password_manager_with_metadata/frontend/package-lock.json
@@ -7,6 +7,7 @@
         "": {
             "name": "password_manager_with_metadata_frontend",
             "version": "0.1.0",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@dfinity/agent": "^2.3.0",
                 "@dfinity/auth-client": "^2.3.0",
@@ -15,6 +16,8 @@
                 "@dfinity/principal": "^2.3.0",
                 "@sveltejs/vite-plugin-svelte": "^3.0.2",
                 "daisyui": "^4.12.23",
+                "ic_vetkd_sdk_encrypted_maps": "file:../../../sdk/ic_vetkd_sdk_encrypted_maps",
+                "save": "^2.9.0",
                 "svelte": "^4.2.19",
                 "svelte-icons": "^2.1.0",
                 "svelte-spa-router": "^4.0.1",
@@ -38,6 +41,23 @@
                 "vite-plugin-eslint": "^1.8.1",
                 "vite-plugin-top-level-await": "^1.4.4",
                 "vite-plugin-wasm": "^3.4.1"
+            }
+        },
+        "../../../sdk/ic_vetkd_sdk_encrypted_maps": {
+            "version": "0.1.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@dfinity/principal": "^2.3.0",
+                "idb-keyval": "^6.2.1"
+            },
+            "devDependencies": {
+                "@eslint/js": "^9.22.0",
+                "eslint": "^9.22.0",
+                "typescript": "^5.8.2",
+                "typescript-eslint": "^8.27.0"
+            },
+            "peerDependencies": {
+                "ic-vetkd-cdk-utils": "^0.1.0"
             }
         },
         "node_modules/@alloc/quick-lru": {
@@ -2089,6 +2109,12 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/async": {
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+            "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+            "license": "MIT"
+        },
         "node_modules/autoprefixer": {
             "version": "10.4.20",
             "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
@@ -2614,6 +2640,12 @@
             "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
             "license": "MIT"
         },
+        "node_modules/duplexer": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+            "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+            "license": "MIT"
+        },
         "node_modules/eastasianwidth": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -2894,6 +2926,21 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/event-stream": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
+            "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
+            "license": "MIT",
+            "dependencies": {
+                "duplexer": "^0.1.1",
+                "from": "^0.1.7",
+                "map-stream": "0.0.7",
+                "pause-stream": "^0.0.11",
+                "split": "^1.0.1",
+                "stream-combiner": "^0.2.2",
+                "through": "^2.3.8"
+            }
+        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3057,6 +3104,12 @@
                 "url": "https://github.com/sponsors/rawify"
             }
         },
+        "node_modules/from": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+            "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
+            "license": "MIT"
+        },
         "node_modules/fs-extra": {
             "version": "10.1.0",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -3175,6 +3228,10 @@
             "engines": {
                 "node": ">= 0.4"
             }
+        },
+        "node_modules/ic_vetkd_sdk_encrypted_maps": {
+            "resolved": "../../../sdk/ic_vetkd_sdk_encrypted_maps",
+            "link": true
         },
         "node_modules/idb": {
             "version": "7.1.1",
@@ -3718,6 +3775,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/lodash.assign": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+            "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw==",
+            "license": "MIT"
+        },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -3739,6 +3802,12 @@
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.0"
             }
+        },
+        "node_modules/map-stream": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+            "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==",
+            "license": "MIT"
         },
         "node_modules/mdn-data": {
             "version": "2.0.30",
@@ -3779,6 +3848,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
+        },
+        "node_modules/mingo": {
+            "version": "6.5.4",
+            "resolved": "https://registry.npmjs.org/mingo/-/mingo-6.5.4.tgz",
+            "integrity": "sha512-oXYTUbNkbzymhfQpsKjMfbtdwPT7ypXazjSANtdybifXYpH3/jmeAzVtW17yCF2UFeiWmdO9kaftgpdhThwprA==",
+            "license": "MIT"
         },
         "node_modules/minimatch": {
             "version": "9.0.5",
@@ -3998,6 +4073,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/pause-stream": {
+            "version": "0.0.11",
+            "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+            "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+            "license": [
+                "MIT",
+                "Apache2"
+            ],
+            "dependencies": {
+                "through": "~2.3"
             }
         },
         "node_modules/periscopic": {
@@ -4460,6 +4547,18 @@
             ],
             "license": "MIT"
         },
+        "node_modules/save": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/save/-/save-2.9.0.tgz",
+            "integrity": "sha512-eg8+g8CjvehE/2C6EbLdtK1pINVD27pcJLj4M9PjWWhoeha/y5bWf4dp/0RF+OzbKTcG1bae9qi3PAqiR8CJTg==",
+            "license": "ISC",
+            "dependencies": {
+                "async": "^3.2.2",
+                "event-stream": "^4.0.1",
+                "lodash.assign": "^4.2.0",
+                "mingo": "^6.1.0"
+            }
+        },
         "node_modules/semver": {
             "version": "7.7.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
@@ -4519,6 +4618,28 @@
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/split": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+            "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+            "license": "MIT",
+            "dependencies": {
+                "through": "2"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/stream-combiner": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+            "integrity": "sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==",
+            "license": "MIT",
+            "dependencies": {
+                "duplexer": "~0.1.1",
+                "through": "~2.3.4"
             }
         },
         "node_modules/string_decoder": {
@@ -4835,6 +4956,12 @@
             "engines": {
                 "node": ">=0.8"
             }
+        },
+        "node_modules/through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+            "license": "MIT"
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",

--- a/examples/password_manager_with_metadata/frontend/package-lock.json
+++ b/examples/password_manager_with_metadata/frontend/package-lock.json
@@ -8,7 +8,11 @@
             "name": "password_manager_with_metadata_frontend",
             "version": "0.1.0",
             "dependencies": {
+                "@dfinity/agent": "^2.3.0",
                 "@dfinity/auth-client": "^2.3.0",
+                "@dfinity/candid": "^2.3.0",
+                "@dfinity/identity": "^2.3.0",
+                "@dfinity/principal": "^2.3.0",
                 "@sveltejs/vite-plugin-svelte": "^3.0.2",
                 "daisyui": "^4.12.23",
                 "svelte": "^4.2.19",
@@ -18,14 +22,15 @@
                 "typewriter-editor": "^0.9.4"
             },
             "devDependencies": {
+                "@eslint/js": "^9.22.0",
                 "@rollup/plugin-typescript": "^12.1.2",
                 "@tailwindcss/postcss": "^4.0.6",
                 "@tailwindcss/vite": "^4.0.0",
                 "autoprefixer": "^10.4.20",
+                "eslint": "^9.22.0",
                 "prettier": "3.5.3",
                 "prettier-plugin-svelte": "^3.3.3",
                 "rollup-plugin-css-only": "^4.5.2",
-                "tslib": "^2.8.1",
                 "typescript-eslint": "^8.26.1",
                 "vite": "^5.4.14",
                 "vite-plugin-compression": "^0.5.1",
@@ -65,7 +70,6 @@
             "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.3.0.tgz",
             "integrity": "sha512-f/eNydwuOunTKRcZAW1RxrcmKyb1AFqZM/ysJJaqFCX9Y+men9NoBTeuUI23XKUp9YeDb9yinGyAlYqjb6VMPw==",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@noble/curves": "^1.4.0",
                 "@noble/hashes": "^1.3.1",
@@ -98,7 +102,6 @@
             "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.3.0.tgz",
             "integrity": "sha512-Xzj3EWfwaVZy90jq6WBRP4Cyqo93r3g8tvBea8W8PN3I4W6KcN2/9ZJaBhT3Y4NP+p2w4ZO6aJ+qp9xH990aYw==",
             "license": "Apache-2.0",
-            "peer": true,
             "peerDependencies": {
                 "@dfinity/principal": "^2.3.0"
             }
@@ -108,7 +111,6 @@
             "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-2.3.0.tgz",
             "integrity": "sha512-nJbL9hNztfhjmdkSmzoUi/cuLmCtjm9/8O6dM100acMjqG1JoW4yF4Mgi/sKwCDCkpj+maY8SqQxI8hSPms9gA==",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@noble/curves": "^1.2.0",
                 "@noble/hashes": "^1.3.1",
@@ -124,7 +126,6 @@
             "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.3.0.tgz",
             "integrity": "sha512-rb3TsxR3L/Vq2GWV/GGIMXPbzDDqxNohPbNW8nJKhpcm8Ds00tCVEmPUDqrn735xJW0Pmzog/6/S1L9jG2UT9g==",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@noble/hashes": "^1.3.1"
             }
@@ -545,7 +546,6 @@
             "integrity": "sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@eslint/object-schema": "^2.1.6",
                 "debug": "^4.3.1",
@@ -561,7 +561,6 @@
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -573,7 +572,6 @@
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -587,7 +585,6 @@
             "integrity": "sha512-kLrdPDJE1ckPo94kmPPf9Hfd0DU0Jw6oKYrhe+pwSC0iTUInmTa+w6fw8sGgcfkFJGNdWOUeOaDM4quW4a7OkA==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
@@ -598,7 +595,6 @@
             "integrity": "sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.15"
             },
@@ -612,7 +608,6 @@
             "integrity": "sha512-yaVPAiNAalnCZedKLdR21GOGILMLKPyqSLWaAjQFvYA2i/ciDi8ArYVr69Anohb6cH2Ukhqti4aFnYyPm8wdwQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
@@ -637,7 +632,6 @@
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -649,7 +643,6 @@
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -663,7 +656,6 @@
             "integrity": "sha512-vLFajx9o8d1/oL2ZkpMYbkLv8nDB6yaIwFNt7nI4+I80U/z03SxmfOMsLbvWr3p7C+Wnoh//aOu2pQW8cS0HCQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
@@ -674,7 +666,6 @@
             "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
@@ -685,7 +676,6 @@
             "integrity": "sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@eslint/core": "^0.12.0",
                 "levn": "^0.4.1"
@@ -700,7 +690,6 @@
             "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": ">=18.18.0"
             }
@@ -711,7 +700,6 @@
             "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@humanfs/core": "^0.19.1",
                 "@humanwhocodes/retry": "^0.3.0"
@@ -726,7 +714,6 @@
             "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": ">=18.18"
             },
@@ -741,7 +728,6 @@
             "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": ">=12.22"
             },
@@ -756,7 +742,6 @@
             "integrity": "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": ">=18.18"
             },
@@ -835,7 +820,6 @@
             "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
             "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@noble/hashes": "1.7.1"
             },
@@ -851,7 +835,6 @@
             "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
             "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": "^14.21.3 || >=16"
             },
@@ -2008,7 +1991,6 @@
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
@@ -2019,7 +2001,6 @@
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -2097,8 +2078,7 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "dev": true,
-            "license": "Python-2.0",
-            "peer": true
+            "license": "Python-2.0"
         },
         "node_modules/aria-query": {
             "version": "5.3.2",
@@ -2166,7 +2146,6 @@
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
             "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ==",
-            "peer": true,
             "engines": {
                 "node": ">= 0.6.0"
             }
@@ -2189,15 +2168,13 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/bignumber.js": {
             "version": "9.1.2",
             "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
             "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": "*"
             }
@@ -2219,7 +2196,6 @@
             "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
             "integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "bignumber.js": "^9.0.0",
                 "buffer": "^5.5.0",
@@ -2252,7 +2228,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.1.13"
@@ -2331,7 +2306,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.2.1"
@@ -2343,7 +2317,6 @@
             "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -2491,16 +2464,14 @@
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
@@ -2601,8 +2572,7 @@
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/deepmerge": {
             "version": "4.3.1",
@@ -2617,8 +2587,7 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
             "integrity": "sha512-a02fiQ7poS5CnjiJBAsjGLPp5EwVoGHNeu9sziBd9huppRfsAFIpv5zNLv0V1gbop53ilngAf5Kf331AwcoRBQ==",
-            "license": "BSD-2-Clause",
-            "peer": true
+            "license": "BSD-2-Clause"
         },
         "node_modules/detect-libc": {
             "version": "1.0.3",
@@ -2732,7 +2701,6 @@
             "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -2746,7 +2714,6 @@
             "integrity": "sha512-9V/QURhsRN40xuHXWjV64yvrzMjcz7ZyNoF2jJFmy9j/SLk0u1OLSZgXi28MrXjymnjEGSR80WCdab3RGMDveQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -2808,7 +2775,6 @@
             "integrity": "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^5.2.0"
@@ -2839,7 +2805,6 @@
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2851,7 +2816,6 @@
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -2865,7 +2829,6 @@
             "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "acorn": "^8.14.0",
                 "acorn-jsx": "^5.3.2",
@@ -2884,7 +2847,6 @@
             "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
             "dev": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "dependencies": {
                 "estraverse": "^5.1.0"
             },
@@ -2898,7 +2860,6 @@
             "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "estraverse": "^5.2.0"
             },
@@ -2912,7 +2873,6 @@
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -2930,7 +2890,6 @@
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -2940,8 +2899,7 @@
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/fast-diff": {
             "version": "1.3.0",
@@ -2982,16 +2940,14 @@
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/fastparse": {
             "version": "1.1.2",
@@ -3014,7 +2970,6 @@
             "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "flat-cache": "^4.0.0"
             },
@@ -3040,7 +2995,6 @@
             "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "locate-path": "^6.0.0",
                 "path-exists": "^4.0.0"
@@ -3058,7 +3012,6 @@
             "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "flatted": "^3.2.9",
                 "keyv": "^4.5.4"
@@ -3072,8 +3025,7 @@
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
             "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
             "dev": true,
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
         },
         "node_modules/foreground-child": {
             "version": "3.3.0",
@@ -3181,7 +3133,6 @@
             "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -3249,8 +3200,7 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/ignore": {
             "version": "5.3.2",
@@ -3268,7 +3218,6 @@
             "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "parent-module": "^1.0.0",
                 "resolve-from": "^4.0.0"
@@ -3286,7 +3235,6 @@
             "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.8.19"
             }
@@ -3295,8 +3243,7 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
         },
         "node_modules/is-binary-path": {
             "version": "2.1.0",
@@ -3384,7 +3331,6 @@
             "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
             "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -3420,7 +3366,6 @@
             "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -3433,31 +3378,27 @@
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
             "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/json-text-sequence": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
             "integrity": "sha512-L3mEegEWHRekSHjc7+sc8eJhba9Clq1PZ8kMkzf8OxElhXc8O4TS5MwcVlj9aEbm5dr81N90WHC5nAz3UO971w==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "delimit-stream": "0.1.0"
             }
@@ -3481,7 +3422,6 @@
             "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "json-buffer": "3.0.1"
             }
@@ -3501,7 +3441,6 @@
             "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1",
                 "type-check": "~0.4.0"
@@ -3769,7 +3708,6 @@
             "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "p-locate": "^5.0.0"
             },
@@ -3785,8 +3723,7 @@
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/lru-cache": {
             "version": "10.4.3",
@@ -3959,7 +3896,6 @@
             "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
@@ -3978,7 +3914,6 @@
             "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "yocto-queue": "^0.1.0"
             },
@@ -3995,7 +3930,6 @@
             "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "p-limit": "^3.0.2"
             },
@@ -4018,7 +3952,6 @@
             "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "callsites": "^3.0.0"
             },
@@ -4032,7 +3965,6 @@
             "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -4274,7 +4206,6 @@
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">= 0.8.0"
             }
@@ -4312,7 +4243,6 @@
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -4351,7 +4281,6 @@
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
             "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -4420,7 +4349,6 @@
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -4530,8 +4458,7 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/semver": {
             "version": "7.7.1",
@@ -4583,8 +4510,7 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/simple-cbor/-/simple-cbor-0.4.1.tgz",
             "integrity": "sha512-rijcxtwx2b4Bje3sqeIqw5EeW7UlOIC4YfOdwqIKacpvRQ/D78bWg/4/0m5e0U91oKvlGh7LlJuZCu07ISCC7w==",
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
         },
         "node_modules/source-map-js": {
             "version": "1.2.1",
@@ -4600,7 +4526,6 @@
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
             "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "safe-buffer": "~5.2.0"
             }
@@ -4707,7 +4632,6 @@
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             },
@@ -4948,7 +4872,9 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "dev": true,
-            "license": "0BSD"
+            "license": "0BSD",
+            "optional": true,
+            "peer": true
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -4956,7 +4882,6 @@
             "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1"
             },
@@ -5062,7 +4987,6 @@
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "punycode": "^2.1.0"
             }
@@ -5290,7 +5214,6 @@
             "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -5404,7 +5327,6 @@
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },

--- a/examples/password_manager_with_metadata/frontend/package.json
+++ b/examples/password_manager_with_metadata/frontend/package.json
@@ -1,6 +1,7 @@
 {
     "name": "password_manager_with_metadata_frontend",
     "version": "0.1.0",
+    "license": "Apache-2.0",
     "type": "module",
     "scripts": {
         "dev": "vite",
@@ -10,15 +11,19 @@
         "preview": "vite preview",
         "gen-bindings": "cd ../backend && make extract-candid && cd .. && dfx generate password_manager_with_metadata && mv src/declarations/password_manager_with_metadata/* frontend/src/declarations/ && rmdir -p src/declarations/password_manager_with_metadata"
     },
+    "peerDependencies": {
+        "ic_vetkd_sdk_encrypted_maps": "^0.1.0"
+    },
     "devDependencies": {
+        "@eslint/js": "^9.22.0",
         "@rollup/plugin-typescript": "^12.1.2",
         "@tailwindcss/postcss": "^4.0.6",
         "@tailwindcss/vite": "^4.0.0",
         "autoprefixer": "^10.4.20",
+        "eslint": "^9.22.0",
         "prettier": "3.5.3",
         "prettier-plugin-svelte": "^3.3.3",
         "rollup-plugin-css-only": "^4.5.2",
-        "tslib": "^2.8.1",
         "typescript-eslint": "^8.26.1",
         "vite": "^5.4.14",
         "vite-plugin-compression": "^0.5.1",
@@ -28,7 +33,11 @@
         "vite-plugin-wasm": "^3.4.1"
     },
     "dependencies": {
+        "@dfinity/agent": "^2.3.0",
         "@dfinity/auth-client": "^2.3.0",
+        "@dfinity/candid": "^2.3.0",
+        "@dfinity/identity": "^2.3.0",
+        "@dfinity/principal": "^2.3.0",
         "@sveltejs/vite-plugin-svelte": "^3.0.2",
         "daisyui": "^4.12.23",
         "svelte": "^4.2.19",

--- a/examples/password_manager_with_metadata/frontend/package.json
+++ b/examples/password_manager_with_metadata/frontend/package.json
@@ -11,9 +11,6 @@
         "preview": "vite preview",
         "gen-bindings": "cd ../backend && make extract-candid && cd .. && dfx generate password_manager_with_metadata && mv src/declarations/password_manager_with_metadata/* frontend/src/declarations/ && rmdir -p src/declarations/password_manager_with_metadata"
     },
-    "peerDependencies": {
-        "ic_vetkd_sdk_encrypted_maps": "^0.1.0"
-    },
     "devDependencies": {
         "@eslint/js": "^9.22.0",
         "@rollup/plugin-typescript": "^12.1.2",
@@ -40,6 +37,8 @@
         "@dfinity/principal": "^2.3.0",
         "@sveltejs/vite-plugin-svelte": "^3.0.2",
         "daisyui": "^4.12.23",
+        "ic_vetkd_sdk_encrypted_maps": "file:../../../sdk/ic_vetkd_sdk_encrypted_maps",
+        "save": "^2.9.0",
         "svelte": "^4.2.19",
         "svelte-icons": "^2.1.0",
         "svelte-spa-router": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "workspaces": [
         "cdk/utils/pkg",
         "sdk/*",
-        "examples/password_manager/frontend"
+        "examples/password_manager/frontend",
+        "examples/password_manager_with_metadata_/frontend"
     ]
 }


### PR DESCRIPTION
Cleanup dependencies in password manager with metadata example. There are a few dependencies that npm-check reports as unused, but they all seem used via svelte.

## Notes

The `ic_vetkd_sdk_encrypted_maps` dependency is now **by path**: I could not make it work otherwise. Even if I declare it as `peerDependency` like this is done for some other modules in the repo, this doesn't work: it then fails when calling `npm install`.

Also added the folder to the workspace, because I thought I need that for the `peerDependency` to work. Even though this actually didn't help for making the `peerDependency` work, I still left it.

## Before
```
examples/password_manager_with_metadata/frontend/ [main] npx npm-check

@sveltejs/vite-plugin-svelte   😎  MAJOR UP  Major update available. https://github.com/sveltejs/vite-plugin-svelte#readme
                                            npm install @sveltejs/vite-plugin-svelte@5.0.3 --save to go from 3.1.2 to 5.0.3

daisyui                        😎  MAJOR UP  Major update available. https://daisyui.com
                                            npm install daisyui@5.0.9 --save to go from 4.12.23 to 5.0.9

svelte                         😎  MAJOR UP  Major update available. https://svelte.dev
                                            npm install svelte@5.24.1 --save to go from 4.2.19 to 5.24.1

svelte-icons                   😕  NOTUSED?  Still using svelte-icons?
                                            Depcheck did not find code similar to require('svelte-icons') or import from 'svelte-icons'.
                                            Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                            Use rc file options to remove unused check, but still monitor for outdated version:
                                                .npmcheckrc {"depcheck": {"ignoreMatches": ["svelte-icons"]}}
                                            Use --skip-unused to skip this check.
                                            To remove this package: npm uninstall svelte-icons --save

tailwindcss                    😎  MAJOR UP  Major update available. https://tailwindcss.com
                                            npm install tailwindcss@4.0.15 --save to go from 3.4.17 to 4.0.15

typewriter-editor              😎  NEW VER!  NonSemver update available. https://github.com/typewriter-editor/typewriter#readme
                                            npm install typewriter-editor@0.12.9 --save to go from 0.9.4 to 0.12.9
                               😕  NOTUSED?  Still using typewriter-editor?
                                            Depcheck did not find code similar to require('typewriter-editor') or import from 'typewriter-editor'.
                                            Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                            Use rc file options to remove unused check, but still monitor for outdated version:
                                                .npmcheckrc {"depcheck": {"ignoreMatches": ["typewriter-editor"]}}
                                            Use --skip-unused to skip this check.
                                            To remove this package: npm uninstall typewriter-editor --save

@tailwindcss/postcss           😍  UPDATE!   Your local install is out of date. https://tailwindcss.com
                                            npm install @tailwindcss/postcss@4.0.15 --save-dev to go from 4.0.8 to 4.0.15
                               😕  NOTUSED?  Still using @tailwindcss/postcss?
                                            Depcheck did not find code similar to require('@tailwindcss/postcss') or import from '@tailwindcss/postcss'.
                                            Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                            Use rc file options to remove unused check, but still monitor for outdated version:
                                                .npmcheckrc {"depcheck": {"ignoreMatches": ["@tailwindcss/postcss"]}}
                                            Use --skip-unused to skip this check.
                                            To remove this package: npm uninstall @tailwindcss/postcss --save-dev

@tailwindcss/vite              😍  UPDATE!   Your local install is out of date. https://tailwindcss.com
                                            npm install @tailwindcss/vite@4.0.15 --save-dev to go from 4.0.8 to 4.0.15
                               😕  NOTUSED?  Still using @tailwindcss/vite?
                                            Depcheck did not find code similar to require('@tailwindcss/vite') or import from '@tailwindcss/vite'.
                                            Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                            Use rc file options to remove unused check, but still monitor for outdated version:
                                                .npmcheckrc {"depcheck": {"ignoreMatches": ["@tailwindcss/vite"]}}
                                            Use --skip-unused to skip this check.
                                            To remove this package: npm uninstall @tailwindcss/vite --save-dev

autoprefixer                   😍  UPDATE!   Your local install is out of date. https://github.com/postcss/autoprefixer#readme
                                            npm install autoprefixer@10.4.21 --save-dev to go from 10.4.20 to 10.4.21

prettier                       😕  NOTUSED?  Still using prettier?
                                            Depcheck did not find code similar to require('prettier') or import from 'prettier'.
                                            Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                            Use rc file options to remove unused check, but still monitor for outdated version:
                                                .npmcheckrc {"depcheck": {"ignoreMatches": ["prettier"]}}
                                            Use --skip-unused to skip this check.
                                            To remove this package: npm uninstall prettier --save-dev

prettier-plugin-svelte         😕  NOTUSED?  Still using prettier-plugin-svelte?
                                            Depcheck did not find code similar to require('prettier-plugin-svelte') or import from 'prettier-plugin-svelte'.
                                            Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                            Use rc file options to remove unused check, but still monitor for outdated version:
                                                .npmcheckrc {"depcheck": {"ignoreMatches": ["prettier-plugin-svelte"]}}
                                            Use --skip-unused to skip this check.
                                            To remove this package: npm uninstall prettier-plugin-svelte --save-dev

typescript-eslint              😍  UPDATE!   Your local install is out of date. https://typescript-eslint.io/packages/typescript-eslint
                                            npm install typescript-eslint@8.27.0 --save-dev to go from 8.26.1 to 8.27.0

vite                           😎  MAJOR UP  Major update available. https://vite.dev
                                            npm install vite@6.2.2 --save-dev to go from 5.4.14 to 6.2.2

@eslint/js                     😟  PKG ERR!  Not in the package.json. Found in: /eslint.config.mjs

@dfinity/identity              😟  PKG ERR!  Not in the package.json. Found in: /src/store/auth.ts

ic_vetkd_sdk_encrypted_maps    😟  MISSING!  Not installed.
                               😟  PKG ERR!  Not in the package.json. Found in: /src/store/vaults.ts, /src/lib/encrypted_maps.ts, /src/lib/password_manager.ts, /src/lib/vault.ts
                               ⛔  NPM ERR!  Registry error Package `ic_vetkd_sdk_encrypted_maps` could not be found

@dfinity/principal             😟  PKG ERR!  Not in the package.json. Found in: /src/store/vaults.ts, /src/lib/password.ts, /src/lib/password_manager.ts, /src/lib/vault.ts, /src/declarations/index.d.ts, /src/declarations/password_manager_with_metadata.did.d.ts

@dfinity/agent                 😟  PKG ERR!  Not in the package.json. Found in: /src/lib/encrypted_maps.ts, /src/lib/password_manager.ts, /src/declarations/index.d.ts, /src/declarations/index.js, /src/declarations/password_manager_with_metadata.did.d.ts

@dfinity/candid                😟  PKG ERR!  Not in the package.json. Found in: /src/declarations/index.d.ts, /src/declarations/password_manager_with_metadata.did.d.ts

Use npm-check -u for interactive update.
```

## After
```
examples/password_manager_with_metadata/frontend/ [franzstefan/fix-pw-mgr-with-metadata-deps] npx npm-check

@sveltejs/vite-plugin-svelte   😎  MAJOR UP  Major update available. https://github.com/sveltejs/vite-plugin-svelte#readme
                                            npm install @sveltejs/vite-plugin-svelte@5.0.3 --save to go from 3.1.2 to 5.0.3

daisyui                        😎  MAJOR UP  Major update available. https://daisyui.com
                                            npm install daisyui@5.0.9 --save to go from 4.12.23 to 5.0.9

save                           😕  NOTUSED?  Still using save?
                                            Depcheck did not find code similar to require('save') or import from 'save'.
                                            Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                            Use rc file options to remove unused check, but still monitor for outdated version:
                                                .npmcheckrc {"depcheck": {"ignoreMatches": ["save"]}}
                                            Use --skip-unused to skip this check.
                                            To remove this package: npm uninstall save --save

svelte                         😎  MAJOR UP  Major update available. https://svelte.dev
                                            npm install svelte@5.24.1 --save to go from 4.2.19 to 5.24.1

svelte-icons                   😕  NOTUSED?  Still using svelte-icons?
                                            Depcheck did not find code similar to require('svelte-icons') or import from 'svelte-icons'.
                                            Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                            Use rc file options to remove unused check, but still monitor for outdated version:
                                                .npmcheckrc {"depcheck": {"ignoreMatches": ["svelte-icons"]}}
                                            Use --skip-unused to skip this check.
                                            To remove this package: npm uninstall svelte-icons --save

tailwindcss                    😎  MAJOR UP  Major update available. https://tailwindcss.com
                                            npm install tailwindcss@4.0.15 --save to go from 3.4.17 to 4.0.15

typewriter-editor              😎  NEW VER!  NonSemver update available. https://github.com/typewriter-editor/typewriter#readme
                                            npm install typewriter-editor@0.12.9 --save to go from 0.9.4 to 0.12.9
                               😕  NOTUSED?  Still using typewriter-editor?
                                            Depcheck did not find code similar to require('typewriter-editor') or import from 'typewriter-editor'.
                                            Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                            Use rc file options to remove unused check, but still monitor for outdated version:
                                                .npmcheckrc {"depcheck": {"ignoreMatches": ["typewriter-editor"]}}
                                            Use --skip-unused to skip this check.
                                            To remove this package: npm uninstall typewriter-editor --save

@tailwindcss/postcss           😍  UPDATE!   Your local install is out of date. https://tailwindcss.com
                                            npm install @tailwindcss/postcss@4.0.15 --save-dev to go from 4.0.8 to 4.0.15
                               😕  NOTUSED?  Still using @tailwindcss/postcss?
                                            Depcheck did not find code similar to require('@tailwindcss/postcss') or import from '@tailwindcss/postcss'.
                                            Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                            Use rc file options to remove unused check, but still monitor for outdated version:
                                                .npmcheckrc {"depcheck": {"ignoreMatches": ["@tailwindcss/postcss"]}}
                                            Use --skip-unused to skip this check.
                                            To remove this package: npm uninstall @tailwindcss/postcss --save-dev

@tailwindcss/vite              😍  UPDATE!   Your local install is out of date. https://tailwindcss.com
                                            npm install @tailwindcss/vite@4.0.15 --save-dev to go from 4.0.8 to 4.0.15
                               😕  NOTUSED?  Still using @tailwindcss/vite?
                                            Depcheck did not find code similar to require('@tailwindcss/vite') or import from '@tailwindcss/vite'.
                                            Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                            Use rc file options to remove unused check, but still monitor for outdated version:
                                                .npmcheckrc {"depcheck": {"ignoreMatches": ["@tailwindcss/vite"]}}
                                            Use --skip-unused to skip this check.
                                            To remove this package: npm uninstall @tailwindcss/vite --save-dev

autoprefixer                   😍  UPDATE!   Your local install is out of date. https://github.com/postcss/autoprefixer#readme
                                            npm install autoprefixer@10.4.21 --save-dev to go from 10.4.20 to 10.4.21

prettier                       😕  NOTUSED?  Still using prettier?
                                            Depcheck did not find code similar to require('prettier') or import from 'prettier'.
                                            Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                            Use rc file options to remove unused check, but still monitor for outdated version:
                                                .npmcheckrc {"depcheck": {"ignoreMatches": ["prettier"]}}
                                            Use --skip-unused to skip this check.
                                            To remove this package: npm uninstall prettier --save-dev

prettier-plugin-svelte         😕  NOTUSED?  Still using prettier-plugin-svelte?
                                            Depcheck did not find code similar to require('prettier-plugin-svelte') or import from 'prettier-plugin-svelte'.
                                            Check your code before removing as depcheck isn't able to foresee all ways dependencies can be used.
                                            Use rc file options to remove unused check, but still monitor for outdated version:
                                                .npmcheckrc {"depcheck": {"ignoreMatches": ["prettier-plugin-svelte"]}}
                                            Use --skip-unused to skip this check.
                                            To remove this package: npm uninstall prettier-plugin-svelte --save-dev

typescript-eslint              😍  UPDATE!   Your local install is out of date. https://typescript-eslint.io/packages/typescript-eslint
                                            npm install typescript-eslint@8.27.0 --save-dev to go from 8.26.1 to 8.27.0

vite                           😎  MAJOR UP  Major update available. https://vite.dev
                                            npm install vite@6.2.2 --save-dev to go from 5.4.14 to 6.2.2

Use npm-check -u for interactive update.
```