### PR TITLE
suggestion: To adjust roles such that listing and retrieving other users permissions is only available to management users

### DIFF
--- a/cdk/key_manager/src/lib.rs
+++ b/cdk/key_manager/src/lib.rs
@@ -101,7 +101,7 @@ impl KeyManager {
         caller: Principal,
         key_id: KeyId,
     ) -> Result<Vec<(Principal, AccessRights)>, String> {
-        self.ensure_user_can_read(caller, key_id)?;
+        self.ensure_user_can_manage(caller, key_id)?;
 
         let users: Vec<_> = self
             .shared_keys
@@ -189,7 +189,7 @@ impl KeyManager {
         key_id: KeyId,
         user: Principal,
     ) -> Result<Option<AccessRights>, String> {
-        self.ensure_user_can_read(caller, key_id)?;
+        self.ensure_user_can_manage(caller, key_id)?;
         Ok(self.ensure_user_can_read(user, key_id).ok())
     }
 


### PR DESCRIPTION
suggestion: For issue #43

Only management users should be able to list users or retrieve another user's access permissions.
