### PR TITLE
fix: typo in a package name

### DIFF
--- a/.github/workflows/cdk.yml
+++ b/.github/workflows/cdk.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     paths:
       - cdk/**
+      - Cargo.toml
+      - Cargo.lock
       - .github/workflows/provision-linux.sh
       - .github/workflows/provision-darwin.sh
 concurrency:

--- a/.github/workflows/encrypted-maps-example.yml
+++ b/.github/workflows/encrypted-maps-example.yml
@@ -10,6 +10,8 @@ on:
       - sdk/ic_vetkd_sdk_encrypted_maps/**
       - sdk/ic_vetkd_sdk_encrypted_maps_example/**
       - sdk/ic_vetkd_sdk_utils/**
+      - package.json
+      - package-lock.json
       - .github/workflows/provision-darwin.sh
       - .github/workflows/provision-linux.sh
       - .github/workflows/encrypted-maps-example.yml

--- a/.github/workflows/examples-password-manager-with-metadata.yml
+++ b/.github/workflows/examples-password-manager-with-metadata.yml
@@ -11,6 +11,8 @@ on:
       - sdk/ic_vetkd_sdk_encrypted_maps/**
       - sdk/ic_vetkd_sdk_encrypted_maps_example/**
       - sdk/ic_vetkd_sdk_utils/**
+      - package.json
+      - package-lock.json
       - .github/workflows/provision-darwin.sh
       - .github/workflows/provision-linux.sh
       - .github/workflows/examples-password-manager-with-metadata.yml

--- a/.github/workflows/examples-password-manager.yml
+++ b/.github/workflows/examples-password-manager.yml
@@ -11,6 +11,8 @@ on:
       - sdk/ic_vetkd_sdk_encrypted_maps/**
       - sdk/ic_vetkd_sdk_encrypted_maps_example/**
       - sdk/ic_vetkd_sdk_utils/**
+      - package.json
+      - package-lock.json
       - .github/workflows/provision-darwin.sh
       - .github/workflows/provision-linux.sh
       - .github/workflows/examples-password-manager.yml

--- a/.github/workflows/key-manager-example.yml
+++ b/.github/workflows/key-manager-example.yml
@@ -13,6 +13,8 @@ on:
       - sdk/ic_vetkd_sdk_key_manager/**
       - sdk/ic_vetkd_sdk_key_manager_example/**
       - sdk/ic_vetkd_sdk_utils/**
+      - package.json
+      - package-lock.json
       - .github/workflows/provision-darwin.sh
       - .github/workflows/provision-linux.sh
       - .github/workflows/key-manager-example.yml

--- a/.github/workflows/sdk_encrypted_maps.yml
+++ b/.github/workflows/sdk_encrypted_maps.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - sdk/ic_sdk_encrypted_maps/**
       - sdk/ic_sdk_utils/**
+      - package.json
+      - package-lock.json
       - .github/workflows/sdk_encrypted_maps.yml
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/sdk_key_manager.yml
+++ b/.github/workflows/sdk_key_manager.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - sdk/ic_sdk_key_manager/**
       - sdk/ic_sdk_utils/**
+      - package.json
+      - package-lock.json
       - .github/workflows/sdk_key_manager.yml
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/sdk_utils.yml
+++ b/.github/workflows/sdk_utils.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     paths:
       - sdk/ic_vetkd_sdk_utils/**
+      - package.json
+      - package-lock.json
       - .github/workflows/sdk_utils.yml
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,656 @@
                 "cdk/utils/pkg",
                 "sdk/*",
                 "examples/password_manager/frontend",
-                "examples/password_manager_with_metadata_/frontend"
+                "examples/password_manager_with_metadata/frontend"
             ]
         },
         "cdk/utils/pkg": {
             "name": "ic-vetkd-cdk-utils",
             "version": "0.1.0"
+        },
+        "examples/password_manager_with_metadata/frontend": {
+            "name": "password_manager_with_metadata_frontend",
+            "version": "0.1.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@dfinity/agent": "^2.3.0",
+                "@dfinity/auth-client": "^2.3.0",
+                "@dfinity/candid": "^2.3.0",
+                "@dfinity/identity": "^2.3.0",
+                "@dfinity/principal": "^2.3.0",
+                "@sveltejs/vite-plugin-svelte": "^3.0.2",
+                "daisyui": "^4.12.23",
+                "save": "^2.9.0",
+                "svelte": "^4.2.19",
+                "svelte-icons": "^2.1.0",
+                "svelte-spa-router": "^4.0.1",
+                "tailwindcss": "^3.0.17",
+                "typewriter-editor": "^0.9.4"
+            },
+            "devDependencies": {
+                "@eslint/js": "^9.22.0",
+                "@rollup/plugin-typescript": "^12.1.2",
+                "@tailwindcss/postcss": "^4.0.6",
+                "@tailwindcss/vite": "^4.0.0",
+                "autoprefixer": "^10.4.20",
+                "eslint": "^9.22.0",
+                "prettier": "3.5.3",
+                "prettier-plugin-svelte": "^3.3.3",
+                "rollup-plugin-css-only": "^4.5.2",
+                "typescript-eslint": "^8.26.1",
+                "vite": "^5.4.14",
+                "vite-plugin-compression": "^0.5.1",
+                "vite-plugin-environment": "^1.1.3",
+                "vite-plugin-eslint": "^1.8.1",
+                "vite-plugin-top-level-await": "^1.4.4",
+                "vite-plugin-wasm": "^3.4.1"
+            },
+            "peerDependencies": {
+                "ic_vetkd_sdk_encrypted_maps": "^0.1.0"
+            }
+        },
+        "examples/password_manager_with_metadata/frontend/node_modules/@esbuild/aix-ppc64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+            "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "examples/password_manager_with_metadata/frontend/node_modules/@esbuild/android-arm": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+            "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "examples/password_manager_with_metadata/frontend/node_modules/@esbuild/android-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+            "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "examples/password_manager_with_metadata/frontend/node_modules/@esbuild/android-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+            "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "examples/password_manager_with_metadata/frontend/node_modules/@esbuild/darwin-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+            "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "examples/password_manager_with_metadata/frontend/node_modules/@esbuild/darwin-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+            "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "examples/password_manager_with_metadata/frontend/node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+            "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "examples/password_manager_with_metadata/frontend/node_modules/@esbuild/freebsd-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+            "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "examples/password_manager_with_metadata/frontend/node_modules/@esbuild/linux-arm": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+            "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "examples/password_manager_with_metadata/frontend/node_modules/@esbuild/linux-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+            "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "examples/password_manager_with_metadata/frontend/node_modules/@esbuild/linux-ia32": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+            "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "examples/password_manager_with_metadata/frontend/node_modules/@esbuild/linux-loong64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+            "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+            "cpu": [
+                "loong64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "examples/password_manager_with_metadata/frontend/node_modules/@esbuild/linux-mips64el": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+            "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+            "cpu": [
+                "mips64el"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "examples/password_manager_with_metadata/frontend/node_modules/@esbuild/linux-ppc64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+            "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "examples/password_manager_with_metadata/frontend/node_modules/@esbuild/linux-riscv64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+            "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "examples/password_manager_with_metadata/frontend/node_modules/@esbuild/linux-s390x": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+            "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+            "cpu": [
+                "s390x"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "examples/password_manager_with_metadata/frontend/node_modules/@esbuild/linux-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+            "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "examples/password_manager_with_metadata/frontend/node_modules/@esbuild/netbsd-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+            "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "examples/password_manager_with_metadata/frontend/node_modules/@esbuild/openbsd-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+            "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "examples/password_manager_with_metadata/frontend/node_modules/@esbuild/sunos-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+            "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "examples/password_manager_with_metadata/frontend/node_modules/@esbuild/win32-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+            "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "examples/password_manager_with_metadata/frontend/node_modules/@esbuild/win32-ia32": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+            "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "examples/password_manager_with_metadata/frontend/node_modules/@esbuild/win32-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+            "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "examples/password_manager_with_metadata/frontend/node_modules/@sveltejs/vite-plugin-svelte": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-3.1.2.tgz",
+            "integrity": "sha512-Txsm1tJvtiYeLUVRNqxZGKR/mI+CzuIQuc2gn+YCs9rMTowpNZ2Nqt53JdL8KF9bLhAf2ruR/dr9eZCwdTriRA==",
+            "license": "MIT",
+            "dependencies": {
+                "@sveltejs/vite-plugin-svelte-inspector": "^2.1.0",
+                "debug": "^4.3.4",
+                "deepmerge": "^4.3.1",
+                "kleur": "^4.1.5",
+                "magic-string": "^0.30.10",
+                "svelte-hmr": "^0.16.0",
+                "vitefu": "^0.2.5"
+            },
+            "engines": {
+                "node": "^18.0.0 || >=20"
+            },
+            "peerDependencies": {
+                "svelte": "^4.0.0 || ^5.0.0-next.0",
+                "vite": "^5.0.0"
+            }
+        },
+        "examples/password_manager_with_metadata/frontend/node_modules/@sveltejs/vite-plugin-svelte/node_modules/@sveltejs/vite-plugin-svelte-inspector": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-2.1.0.tgz",
+            "integrity": "sha512-9QX28IymvBlSCqsCll5t0kQVxipsfhFFL+L2t3nTWfXnddYwxBuAEtTtlaVQpRz9c37BhJjltSeY4AJSC03SSg==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": "^18.0.0 || >=20"
+            },
+            "peerDependencies": {
+                "@sveltejs/vite-plugin-svelte": "^3.0.0",
+                "svelte": "^4.0.0 || ^5.0.0-next.0",
+                "vite": "^5.0.0"
+            }
+        },
+        "examples/password_manager_with_metadata/frontend/node_modules/arg": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+            "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+            "license": "MIT"
+        },
+        "examples/password_manager_with_metadata/frontend/node_modules/esbuild": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+            "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.21.5",
+                "@esbuild/android-arm": "0.21.5",
+                "@esbuild/android-arm64": "0.21.5",
+                "@esbuild/android-x64": "0.21.5",
+                "@esbuild/darwin-arm64": "0.21.5",
+                "@esbuild/darwin-x64": "0.21.5",
+                "@esbuild/freebsd-arm64": "0.21.5",
+                "@esbuild/freebsd-x64": "0.21.5",
+                "@esbuild/linux-arm": "0.21.5",
+                "@esbuild/linux-arm64": "0.21.5",
+                "@esbuild/linux-ia32": "0.21.5",
+                "@esbuild/linux-loong64": "0.21.5",
+                "@esbuild/linux-mips64el": "0.21.5",
+                "@esbuild/linux-ppc64": "0.21.5",
+                "@esbuild/linux-riscv64": "0.21.5",
+                "@esbuild/linux-s390x": "0.21.5",
+                "@esbuild/linux-x64": "0.21.5",
+                "@esbuild/netbsd-x64": "0.21.5",
+                "@esbuild/openbsd-x64": "0.21.5",
+                "@esbuild/sunos-x64": "0.21.5",
+                "@esbuild/win32-arm64": "0.21.5",
+                "@esbuild/win32-ia32": "0.21.5",
+                "@esbuild/win32-x64": "0.21.5"
+            }
+        },
+        "examples/password_manager_with_metadata/frontend/node_modules/glob-parent": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+            "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.3"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "examples/password_manager_with_metadata/frontend/node_modules/jiti": {
+            "version": "1.21.7",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+            "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+            "license": "MIT",
+            "bin": {
+                "jiti": "bin/jiti.js"
+            }
+        },
+        "examples/password_manager_with_metadata/frontend/node_modules/kleur": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+            "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "examples/password_manager_with_metadata/frontend/node_modules/svelte-hmr": {
+            "version": "0.16.0",
+            "resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.16.0.tgz",
+            "integrity": "sha512-Gyc7cOS3VJzLlfj7wKS0ZnzDVdv3Pn2IuVeJPk9m2skfhcu5bq3wtIZyQGggr7/Iim5rH5cncyQft/kRLupcnA==",
+            "license": "ISC",
+            "engines": {
+                "node": "^12.20 || ^14.13.1 || >= 16"
+            },
+            "peerDependencies": {
+                "svelte": "^3.19.0 || ^4.0.0"
+            }
+        },
+        "examples/password_manager_with_metadata/frontend/node_modules/tailwindcss": {
+            "version": "3.4.17",
+            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
+            "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
+            "license": "MIT",
+            "dependencies": {
+                "@alloc/quick-lru": "^5.2.0",
+                "arg": "^5.0.2",
+                "chokidar": "^3.6.0",
+                "didyoumean": "^1.2.2",
+                "dlv": "^1.1.3",
+                "fast-glob": "^3.3.2",
+                "glob-parent": "^6.0.2",
+                "is-glob": "^4.0.3",
+                "jiti": "^1.21.6",
+                "lilconfig": "^3.1.3",
+                "micromatch": "^4.0.8",
+                "normalize-path": "^3.0.0",
+                "object-hash": "^3.0.0",
+                "picocolors": "^1.1.1",
+                "postcss": "^8.4.47",
+                "postcss-import": "^15.1.0",
+                "postcss-js": "^4.0.1",
+                "postcss-load-config": "^4.0.2",
+                "postcss-nested": "^6.2.0",
+                "postcss-selector-parser": "^6.1.2",
+                "resolve": "^1.22.8",
+                "sucrase": "^3.35.0"
+            },
+            "bin": {
+                "tailwind": "lib/cli.js",
+                "tailwindcss": "lib/cli.js"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "examples/password_manager_with_metadata/frontend/node_modules/vite": {
+            "version": "5.4.15",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.15.tgz",
+            "integrity": "sha512-6ANcZRivqL/4WtwPGTKNaosuNJr5tWiftOC7liM7G9+rMb8+oeJeyzymDu4rTN93seySBmbjSfsS3Vzr19KNtA==",
+            "license": "MIT",
+            "dependencies": {
+                "esbuild": "^0.21.3",
+                "postcss": "^8.4.43",
+                "rollup": "^4.20.0"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^18.0.0 || >=20.0.0",
+                "less": "*",
+                "lightningcss": "^1.21.0",
+                "sass": "*",
+                "sass-embedded": "*",
+                "stylus": "*",
+                "sugarss": "*",
+                "terser": "^5.4.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "lightningcss": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                }
+            }
+        },
+        "examples/password_manager_with_metadata/frontend/node_modules/vitefu": {
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-0.2.5.tgz",
+            "integrity": "sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==",
+            "license": "MIT",
+            "peerDependencies": {
+                "vite": "^3.0.0 || ^4.0.0 || ^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "vite": {
+                    "optional": true
+                }
+            }
         },
         "examples/password_manager/frontend": {
             "version": "0.1.0",
@@ -455,15 +1099,6 @@
                 "vite": "^5.0.0"
             }
         },
-        "examples/password_manager/frontend/node_modules/@typewriter/document": {
-            "version": "0.7.11",
-            "resolved": "https://registry.npmjs.org/@typewriter/document/-/document-0.7.11.tgz",
-            "integrity": "sha512-DAmQaYAe5RRXMtdOBMo/COeBw4Zr97uOAt3e9hUY7xT5j3AYx0EPrzJKMM40ZQ7Oh+w3n3g+kV/UuftIK1zEQg==",
-            "license": "MIT",
-            "dependencies": {
-                "@typewriter/delta": "^1.0.2"
-            }
-        },
         "examples/password_manager/frontend/node_modules/arg": {
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -573,19 +1208,6 @@
             },
             "engines": {
                 "node": ">=14.0.0"
-            }
-        },
-        "examples/password_manager/frontend/node_modules/typewriter-editor": {
-            "version": "0.9.4",
-            "resolved": "https://registry.npmjs.org/typewriter-editor/-/typewriter-editor-0.9.4.tgz",
-            "integrity": "sha512-SJ17/ulwN38pzXanq0YP8zZ0bN/ajdwswKm9XZCKDNCL9KE/00+xj5LY6PGNTpVly8LSfoIXbL7Lxo0uKmwNvA==",
-            "license": "MIT",
-            "dependencies": {
-                "@popperjs/core": "^2.11.8",
-                "@typewriter/document": "^0.7.11"
-            },
-            "peerDependencies": {
-                "svelte": ">=3.43.0 <5"
             }
         },
         "examples/password_manager/frontend/node_modules/vite": {
@@ -4796,6 +5418,17 @@
                 "@babel/types": "^7.20.7"
             }
         },
+        "node_modules/@types/eslint": {
+            "version": "8.56.12",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.12.tgz",
+            "integrity": "sha512-03ruubjWyOHlmljCVoxSuNDdmfZDzsrrz0P2LeJsOXr+ZwFQ+0yQIwNCwt/GYhV7Z31fgtXJTAEs+FYlEL851g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "*",
+                "@types/json-schema": "*"
+            }
+        },
         "node_modules/@types/estree": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -5112,6 +5745,15 @@
             "license": "MIT",
             "dependencies": {
                 "fast-diff": "1.3.0"
+            }
+        },
+        "node_modules/@typewriter/document": {
+            "version": "0.7.11",
+            "resolved": "https://registry.npmjs.org/@typewriter/document/-/document-0.7.11.tgz",
+            "integrity": "sha512-DAmQaYAe5RRXMtdOBMo/COeBw4Zr97uOAt3e9hUY7xT5j3AYx0EPrzJKMM40ZQ7Oh+w3n3g+kV/UuftIK1zEQg==",
+            "license": "MIT",
+            "dependencies": {
+                "@typewriter/delta": "^1.0.2"
             }
         },
         "node_modules/@vitest/coverage-v8": {
@@ -5507,6 +6149,12 @@
             "engines": {
                 "node": ">=12"
             }
+        },
+        "node_modules/async": {
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+            "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+            "license": "MIT"
         },
         "node_modules/asynckit": {
             "version": "0.4.0",
@@ -6235,7 +6883,6 @@
             "version": "0.8.0",
             "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.8.0.tgz",
             "integrity": "sha512-Jd6Ig3/pe62/qe5SBPTN8h8LeUg/pT4lLgtavPf7updwwHpvFzxvOQBHYj2LZDMjUnBzgvIUSjRcf6oT5HzHFg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -6287,7 +6934,6 @@
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/culori/-/culori-3.3.0.tgz",
             "integrity": "sha512-pHJg+jbuFsCjz9iclQBqyL3B2HLCBF71BwVNujUYEvCeQMvV97R59MNK3R2+jgJ3a1fcZgI9B3vYgz8lzr/BFQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -6297,7 +6943,6 @@
             "version": "4.12.23",
             "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-4.12.23.tgz",
             "integrity": "sha512-EM38duvxutJ5PD65lO/AFMpcw+9qEy6XAZrTpzp7WyaPeO/l+F/Qiq0ECHHmFNcFXh5aVoALY4MGrrxtCiaQCQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "css-selector-tokenizer": "^0.8",
@@ -6510,6 +7155,12 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
             "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+            "license": "MIT"
+        },
+        "node_modules/duplexer": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+            "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
             "license": "MIT"
         },
         "node_modules/eastasianwidth": {
@@ -6900,6 +7551,21 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/event-stream": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
+            "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
+            "license": "MIT",
+            "dependencies": {
+                "duplexer": "^0.1.1",
+                "from": "^0.1.7",
+                "map-stream": "0.0.7",
+                "pause-stream": "^0.0.11",
+                "split": "^1.0.1",
+                "stream-combiner": "^0.2.2",
+                "through": "^2.3.8"
+            }
+        },
         "node_modules/execa": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -7017,7 +7683,6 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
             "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/fastq": {
@@ -7157,9 +7822,30 @@
                 "url": "https://github.com/sponsors/rawify"
             }
         },
+        "node_modules/from": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+            "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
+            "license": "MIT"
+        },
         "node_modules/frontend": {
             "resolved": "examples/password_manager/frontend",
             "link": true
+        },
+        "node_modules/fs-extra": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
@@ -8581,6 +9267,19 @@
                 "node": ">=6"
             }
         },
+        "node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
         "node_modules/keyv": {
             "version": "4.5.4",
             "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -8890,6 +9589,12 @@
                 "node": ">=8"
             }
         },
+        "node_modules/lodash.assign": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+            "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw==",
+            "license": "MIT"
+        },
         "node_modules/lodash.debounce": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -8989,6 +9694,12 @@
                 "tmpl": "1.0.5"
             }
         },
+        "node_modules/map-stream": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+            "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==",
+            "license": "MIT"
+        },
         "node_modules/mdn-data": {
             "version": "2.0.30",
             "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
@@ -9060,6 +9771,12 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/mingo": {
+            "version": "6.5.5",
+            "resolved": "https://registry.npmjs.org/mingo/-/mingo-6.5.5.tgz",
+            "integrity": "sha512-m5I6BP/U2S7+gqxRQ+BUW3y6TcQ5QY07jmCZ6co2Jz9A5y3y4AlbWzQHdq9SKpiujAViHcI94ffPgmzteNjcOA==",
+            "license": "MIT"
         },
         "node_modules/minimatch": {
             "version": "3.1.2",
@@ -9369,6 +10086,10 @@
                 "url": "https://github.com/inikulin/parse5?sponsor=1"
             }
         },
+        "node_modules/password_manager_with_metadata_frontend": {
+            "resolved": "examples/password_manager_with_metadata/frontend",
+            "link": true
+        },
         "node_modules/path-exists": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -9441,6 +10162,18 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 14.16"
+            }
+        },
+        "node_modules/pause-stream": {
+            "version": "0.0.11",
+            "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+            "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+            "license": [
+                "MIT",
+                "Apache2"
+            ],
+            "dependencies": {
+                "through": "~2.3"
             }
         },
         "node_modules/periscopic": {
@@ -9645,6 +10378,33 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/prettier": {
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+            "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "prettier": "bin/prettier.cjs"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        },
+        "node_modules/prettier-plugin-svelte": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.3.3.tgz",
+            "integrity": "sha512-yViK9zqQ+H2qZD1w/bH7W8i+bVfKrD8GIFjkFe4Thl6kCT9SlAsXVNmt3jCvQOCsnOhcvYgsoVlRV/Eu6x5nNw==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "prettier": "^3.0.0",
+                "svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
             }
         },
         "node_modules/pretty-format": {
@@ -10071,6 +10831,18 @@
             "optional": true,
             "peer": true
         },
+        "node_modules/save": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/save/-/save-2.9.0.tgz",
+            "integrity": "sha512-eg8+g8CjvehE/2C6EbLdtK1pINVD27pcJLj4M9PjWWhoeha/y5bWf4dp/0RF+OzbKTcG1bae9qi3PAqiR8CJTg==",
+            "license": "ISC",
+            "dependencies": {
+                "async": "^3.2.2",
+                "event-stream": "^4.0.1",
+                "lodash.assign": "^4.2.0",
+                "mingo": "^6.1.0"
+            }
+        },
         "node_modules/saxes": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -10184,6 +10956,18 @@
                 "source-map": "^0.6.0"
             }
         },
+        "node_modules/split": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+            "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+            "license": "MIT",
+            "dependencies": {
+                "through": "2"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -10217,6 +11001,16 @@
             "integrity": "sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/stream-combiner": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+            "integrity": "sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==",
+            "license": "MIT",
+            "dependencies": {
+                "duplexer": "~0.1.1",
+                "through": "~2.3.4"
+            }
         },
         "node_modules/string_decoder": {
             "version": "1.3.0",
@@ -10543,6 +11337,12 @@
                 "node": ">=0.8"
             }
         },
+        "node_modules/through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+            "license": "MIT"
+        },
         "node_modules/tinybench": {
             "version": "2.9.0",
             "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -10798,6 +11598,19 @@
                 "typescript": ">=4.8.4 <5.9.0"
             }
         },
+        "node_modules/typewriter-editor": {
+            "version": "0.9.4",
+            "resolved": "https://registry.npmjs.org/typewriter-editor/-/typewriter-editor-0.9.4.tgz",
+            "integrity": "sha512-SJ17/ulwN38pzXanq0YP8zZ0bN/ajdwswKm9XZCKDNCL9KE/00+xj5LY6PGNTpVly8LSfoIXbL7Lxo0uKmwNvA==",
+            "license": "MIT",
+            "dependencies": {
+                "@popperjs/core": "^2.11.8",
+                "@typewriter/document": "^0.7.11"
+            },
+            "peerDependencies": {
+                "svelte": ">=3.43.0 <5"
+            }
+        },
         "node_modules/undici-types": {
             "version": "6.20.0",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
@@ -10846,6 +11659,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.0.0"
             }
         },
         "node_modules/update-browserslist-db": {
@@ -11024,6 +11847,21 @@
                 "url": "https://opencollective.com/vitest"
             }
         },
+        "node_modules/vite-plugin-compression": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/vite-plugin-compression/-/vite-plugin-compression-0.5.1.tgz",
+            "integrity": "sha512-5QJKBDc+gNYVqL/skgFAP81Yuzo9R+EAf19d+EtsMF/i8kFUpNi3J/H01QD3Oo8zBQn+NzoCIFkpPLynoOzaJg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^4.1.2",
+                "debug": "^4.3.3",
+                "fs-extra": "^10.0.0"
+            },
+            "peerDependencies": {
+                "vite": ">=2.0.0"
+            }
+        },
         "node_modules/vite-plugin-environment": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/vite-plugin-environment/-/vite-plugin-environment-1.1.3.tgz",
@@ -11032,6 +11870,59 @@
             "license": "MIT",
             "peerDependencies": {
                 "vite": ">= 2.7"
+            }
+        },
+        "node_modules/vite-plugin-eslint": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/vite-plugin-eslint/-/vite-plugin-eslint-1.8.1.tgz",
+            "integrity": "sha512-PqdMf3Y2fLO9FsNPmMX+//2BF5SF8nEWspZdgl4kSt7UvHDRHVVfHvxsD7ULYzZrJDGRxR81Nq7TOFgwMnUang==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rollup/pluginutils": "^4.2.1",
+                "@types/eslint": "^8.4.5",
+                "rollup": "^2.77.2"
+            },
+            "peerDependencies": {
+                "eslint": ">=7",
+                "vite": ">=2"
+            }
+        },
+        "node_modules/vite-plugin-eslint/node_modules/@rollup/pluginutils": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+            "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "estree-walker": "^2.0.1",
+                "picomatch": "^2.2.2"
+            },
+            "engines": {
+                "node": ">= 8.0.0"
+            }
+        },
+        "node_modules/vite-plugin-eslint/node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/vite-plugin-eslint/node_modules/rollup": {
+            "version": "2.79.2",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
+            "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "rollup": "dist/bin/rollup"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.2"
             }
         },
         "node_modules/vite-plugin-top-level-await": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
         "cdk/utils/pkg",
         "sdk/*",
         "examples/password_manager/frontend",
-        "examples/password_manager_with_metadata_/frontend"
+        "examples/password_manager_with_metadata/frontend"
     ]
 }


### PR DESCRIPTION
Because of the typo the `password_manager_with_metadata_frontend` package was compiled in its own workspace, causing it to include many dependencies twice (we don't use explicit deduplication in `vite` in the `examples`) .

The change in the compiled size is `1028.35kb / gzip: 267.23kb -> 493.31kb / gzip: 159.32kb`.