### PR TITLE
chore: remove WASM plugins

### DIFF
--- a/examples/password_manager/frontend/package.json
+++ b/examples/password_manager/frontend/package.json
@@ -17,9 +17,7 @@
     "daisyui": "^4.12.23",
     "svelte": "^4.2.19",
     "vite": "^5.4.14",
-    "vite-plugin-environment": "^1.1.3",
-    "vite-plugin-top-level-await": "^1.4.4",
-    "vite-plugin-wasm": "^3.4.1"
+    "vite-plugin-environment": "^1.1.3"
   },
   "dependencies": {
     "@dfinity/agent": "^2.3.0",

--- a/examples/password_manager/frontend/vite.config.js
+++ b/examples/password_manager/frontend/vite.config.js
@@ -1,7 +1,5 @@
 import { defineConfig } from 'vite'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
-import wasm from "vite-plugin-wasm";
-import topLevelAwait from "vite-plugin-top-level-await";
 import tailwindcss from 'tailwindcss'
 import autoprefixer from "autoprefixer";
 import css from 'rollup-plugin-css-only';
@@ -14,8 +12,6 @@ const production = false;// !process.env.VITE_WATCH_MODE;
 export default defineConfig({
   plugins: [
     svelte(),
-    wasm(),
-    topLevelAwait(),
     css({ output: "bundle.css" }),
     typescript({
       sourceMap: true,
@@ -24,11 +20,6 @@ export default defineConfig({
     environment("all", { prefix: "CANISTER_" }),
     environment("all", { prefix: "DFX_" }),
   ],
-  esbuild: {
-    supported: {
-      'top-level-await': true //browsers can handle top-level-await features
-    },
-  },
   css: {
     postcss: {
       plugins: [autoprefixer(), tailwindcss()],

--- a/examples/password_manager_with_metadata/frontend/package-lock.json
+++ b/examples/password_manager_with_metadata/frontend/package-lock.json
@@ -37,9 +37,7 @@
                 "vite": "^5.4.14",
                 "vite-plugin-compression": "^0.5.1",
                 "vite-plugin-environment": "^1.1.3",
-                "vite-plugin-eslint": "^1.8.1",
-                "vite-plugin-top-level-await": "^1.4.4",
-                "vite-plugin-wasm": "^3.4.1"
+                "vite-plugin-eslint": "^1.8.1"
             },
             "peerDependencies": {
                 "ic_vetkd_sdk_encrypted_maps": "^0.1.0"
@@ -947,24 +945,6 @@
                 }
             }
         },
-        "node_modules/@rollup/plugin-virtual": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@rollup/plugin-virtual/-/plugin-virtual-3.0.2.tgz",
-            "integrity": "sha512-10monEYsBp3scM4/ND4LNH5Rxvh3e/cVeL3jWTgZ2SrQ+BmUoQcopVQvnaMcOnykb1VkxUFuDAN+0FnpTFRy2A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "peerDependencies": {
-                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-            },
-            "peerDependenciesMeta": {
-                "rollup": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@rollup/pluginutils": {
             "version": "5.1.4",
             "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.4.tgz",
@@ -1272,232 +1252,6 @@
                 "@sveltejs/vite-plugin-svelte": "^3.0.0",
                 "svelte": "^4.0.0 || ^5.0.0-next.0",
                 "vite": "^5.0.0"
-            }
-        },
-        "node_modules/@swc/core": {
-            "version": "1.10.18",
-            "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.10.18.tgz",
-            "integrity": "sha512-IUWKD6uQYGRy8w2X9EZrtYg1O3SCijlHbCXzMaHQYc1X7yjijQh4H3IVL9ssZZyVp2ZDfQZu4bD5DWxxvpyjvg==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@swc/counter": "^0.1.3",
-                "@swc/types": "^0.1.17"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/swc"
-            },
-            "optionalDependencies": {
-                "@swc/core-darwin-arm64": "1.10.18",
-                "@swc/core-darwin-x64": "1.10.18",
-                "@swc/core-linux-arm-gnueabihf": "1.10.18",
-                "@swc/core-linux-arm64-gnu": "1.10.18",
-                "@swc/core-linux-arm64-musl": "1.10.18",
-                "@swc/core-linux-x64-gnu": "1.10.18",
-                "@swc/core-linux-x64-musl": "1.10.18",
-                "@swc/core-win32-arm64-msvc": "1.10.18",
-                "@swc/core-win32-ia32-msvc": "1.10.18",
-                "@swc/core-win32-x64-msvc": "1.10.18"
-            },
-            "peerDependencies": {
-                "@swc/helpers": "*"
-            },
-            "peerDependenciesMeta": {
-                "@swc/helpers": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@swc/core-darwin-arm64": {
-            "version": "1.10.18",
-            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.10.18.tgz",
-            "integrity": "sha512-FdGqzAIKVQJu8ROlnHElP59XAUsUzCFSNsou+tY/9ba+lhu8R9v0OI5wXiPErrKGZpQFMmx/BPqqhx3X4SuGNg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@swc/core-darwin-x64": {
-            "version": "1.10.18",
-            "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.10.18.tgz",
-            "integrity": "sha512-RZ73gZRituL/ZVLgrW6BYnQ5g8tuStG4cLUiPGJsUZpUm0ullSH6lHFvZTCBNFTfpQChG6eEhi2IdG6DwFp1lw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@swc/core-linux-arm-gnueabihf": {
-            "version": "1.10.18",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.10.18.tgz",
-            "integrity": "sha512-8iJqI3EkxJuuq21UHoen1VS+QlS23RvynRuk95K+Q2HBjygetztCGGEc+Xelx9a0uPkDaaAtFvds4JMDqb9SAA==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@swc/core-linux-arm64-gnu": {
-            "version": "1.10.18",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.10.18.tgz",
-            "integrity": "sha512-8f1kSktWzMB6PG+r8lOlCfXz5E8Qhsmfwonn77T/OfjvGwQaWrcoASh2cdjpk3dydbf8jsKGPQE1lSc7GyjXRQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@swc/core-linux-arm64-musl": {
-            "version": "1.10.18",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.10.18.tgz",
-            "integrity": "sha512-4rv+E4VLdgQw6zjbTAauCAEExxChvxMpBUMCiZweTNPKbJJ2dY6BX2WGJ1ea8+RcgqR/Xysj3AFbOz1LBz6dGA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@swc/core-linux-x64-gnu": {
-            "version": "1.10.18",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.10.18.tgz",
-            "integrity": "sha512-vTNmyRBVP+sZca+vtwygYPGTNudTU6Gl6XhaZZ7cEUTBr8xvSTgEmYXoK/2uzyXpaTUI4Bmtp1x81cGN0mMoLQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@swc/core-linux-x64-musl": {
-            "version": "1.10.18",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.10.18.tgz",
-            "integrity": "sha512-1TZPReKhFCeX776XaT6wegknfg+g3zODve+r4oslFHI+g7cInfWlxoGNDS3niPKyuafgCdOjme2g3OF+zzxfsQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@swc/core-win32-arm64-msvc": {
-            "version": "1.10.18",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.10.18.tgz",
-            "integrity": "sha512-o/2CsaWSN3bkzVQ6DA+BiFKSVEYvhWGA1h+wnL2zWmIDs2Knag54sOEXZkCaf8YQyZesGeXJtPEy9hh/vjJgkA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@swc/core-win32-ia32-msvc": {
-            "version": "1.10.18",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.10.18.tgz",
-            "integrity": "sha512-eTPASeJtk4mJDfWiYEiOC6OYUi/N7meHbNHcU8e+aKABonhXrIo/FmnTE8vsUtC6+jakT1TQBdiQ8fzJ1kJVwA==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@swc/core-win32-x64-msvc": {
-            "version": "1.10.18",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.10.18.tgz",
-            "integrity": "sha512-1Dud8CDBnc34wkBOboFBQud9YlV1bcIQtKSg7zC8LtwR3h+XAaCayZPkpGmmAlCv1DLQPvkF+s0JcaVC9mfffQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@swc/counter": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
-            "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-            "dev": true,
-            "license": "Apache-2.0"
-        },
-        "node_modules/@swc/types": {
-            "version": "0.1.17",
-            "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.17.tgz",
-            "integrity": "sha512-V5gRru+aD8YVyCOMAjMpWR1Ui577DD5KSJsHP8RAxopAH22jFz6GZd/qxqjO6MJHQhcsjvjOFXyDhyLQUnMveQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@swc/counter": "^0.1.3"
             }
         },
         "node_modules/@tailwindcss/node": {
@@ -5127,20 +4881,6 @@
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "license": "MIT"
         },
-        "node_modules/uuid": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-            "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-            "dev": true,
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
-        },
         "node_modules/vite": {
             "version": "5.4.14",
             "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.14.tgz",
@@ -5282,31 +5022,6 @@
             },
             "optionalDependencies": {
                 "fsevents": "~2.3.2"
-            }
-        },
-        "node_modules/vite-plugin-top-level-await": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/vite-plugin-top-level-await/-/vite-plugin-top-level-await-1.5.0.tgz",
-            "integrity": "sha512-r/DtuvHrSqUVk23XpG2cl8gjt1aATMG5cjExXL1BUTcSNab6CzkcPua9BPEc9fuTP5UpwClCxUe3+dNGL0yrgQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@rollup/plugin-virtual": "^3.0.2",
-                "@swc/core": "^1.10.16",
-                "uuid": "^10.0.0"
-            },
-            "peerDependencies": {
-                "vite": ">=2.8"
-            }
-        },
-        "node_modules/vite-plugin-wasm": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/vite-plugin-wasm/-/vite-plugin-wasm-3.4.1.tgz",
-            "integrity": "sha512-ja3nSo2UCkVeitltJGkS3pfQHAanHv/DqGatdI39ja6McgABlpsZ5hVgl6wuR8Qx5etY3T5qgDQhOWzc5RReZA==",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "vite": "^2 || ^3 || ^4 || ^5 || ^6"
             }
         },
         "node_modules/vitefu": {

--- a/examples/password_manager_with_metadata/frontend/package.json
+++ b/examples/password_manager_with_metadata/frontend/package.json
@@ -28,9 +28,7 @@
         "vite": "^5.4.14",
         "vite-plugin-compression": "^0.5.1",
         "vite-plugin-environment": "^1.1.3",
-        "vite-plugin-eslint": "^1.8.1",
-        "vite-plugin-top-level-await": "^1.4.4",
-        "vite-plugin-wasm": "^3.4.1"
+        "vite-plugin-eslint": "^1.8.1"
     },
     "dependencies": {
         "@dfinity/agent": "^2.3.0",

--- a/examples/password_manager_with_metadata/frontend/vite.config.js
+++ b/examples/password_manager_with_metadata/frontend/vite.config.js
@@ -1,8 +1,6 @@
 import { defineConfig } from 'vite'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 import eslint from 'vite-plugin-eslint'
-import wasm from "vite-plugin-wasm";
-import topLevelAwait from "vite-plugin-top-level-await";
 import tailwindcss from 'tailwindcss'
 import autoprefixer from "autoprefixer";
 import css from 'rollup-plugin-css-only';
@@ -14,8 +12,6 @@ import environment from 'vite-plugin-environment';
 export default defineConfig({
   plugins: [
     svelte(),
-    wasm(),
-    topLevelAwait(),
     css({ output: "bundle.css" }),
     eslint(),
     typescript({
@@ -25,11 +21,6 @@ export default defineConfig({
     environment("all", { prefix: "CANISTER_" }),
     environment("all", { prefix: "DFX_" }),
   ],
-  esbuild: {
-    supported: {
-      'top-level-await': true //browsers can handle top-level-await features
-    },
-  },
   css: {
     postcss: {
       plugins: [autoprefixer(), tailwindcss()],

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,9 +48,7 @@
                 "vite": "^5.4.14",
                 "vite-plugin-compression": "^0.5.1",
                 "vite-plugin-environment": "^1.1.3",
-                "vite-plugin-eslint": "^1.8.1",
-                "vite-plugin-top-level-await": "^1.4.4",
-                "vite-plugin-wasm": "^3.4.1"
+                "vite-plugin-eslint": "^1.8.1"
             },
             "peerDependencies": {
                 "ic_vetkd_sdk_encrypted_maps": "^0.1.0"
@@ -11907,29 +11905,6 @@
             },
             "optionalDependencies": {
                 "fsevents": "~2.3.2"
-            }
-        },
-        "node_modules/vite-plugin-top-level-await": {
-            "version": "1.4.4",
-            "resolved": "https://registry.npmjs.org/vite-plugin-top-level-await/-/vite-plugin-top-level-await-1.4.4.tgz",
-            "integrity": "sha512-QyxQbvcMkgt+kDb12m2P8Ed35Sp6nXP+l8ptGrnHV9zgYDUpraO0CPdlqLSeBqvY2DToR52nutDG7mIHuysdiw==",
-            "license": "MIT",
-            "dependencies": {
-                "@rollup/plugin-virtual": "^3.0.2",
-                "@swc/core": "^1.7.0",
-                "uuid": "^10.0.0"
-            },
-            "peerDependencies": {
-                "vite": ">=2.8"
-            }
-        },
-        "node_modules/vite-plugin-wasm": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/vite-plugin-wasm/-/vite-plugin-wasm-3.4.1.tgz",
-            "integrity": "sha512-ja3nSo2UCkVeitltJGkS3pfQHAanHv/DqGatdI39ja6McgABlpsZ5hVgl6wuR8Qx5etY3T5qgDQhOWzc5RReZA==",
-            "license": "MIT",
-            "peerDependencies": {
-                "vite": "^2 || ^3 || ^4 || ^5 || ^6"
             }
         },
         "node_modules/vitest": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,9 +39,7 @@
                 "daisyui": "^4.12.23",
                 "svelte": "^4.2.19",
                 "vite": "^5.4.14",
-                "vite-plugin-environment": "^1.1.3",
-                "vite-plugin-top-level-await": "^1.4.4",
-                "vite-plugin-wasm": "^3.4.1"
+                "vite-plugin-environment": "^1.1.3"
             },
             "peerDependencies": {
                 "ic_vetkd_sdk_encrypted_maps": "^0.1.0",
@@ -3928,23 +3926,6 @@
                 }
             }
         },
-        "node_modules/@rollup/plugin-virtual": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@rollup/plugin-virtual/-/plugin-virtual-3.0.2.tgz",
-            "integrity": "sha512-10monEYsBp3scM4/ND4LNH5Rxvh3e/cVeL3jWTgZ2SrQ+BmUoQcopVQvnaMcOnykb1VkxUFuDAN+0FnpTFRy2A==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "peerDependencies": {
-                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-            },
-            "peerDependenciesMeta": {
-                "rollup": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@rollup/pluginutils": {
             "version": "5.1.4",
             "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.4.tgz",
@@ -4265,6 +4246,8 @@
             "integrity": "sha512-WSrnE6JRnH20ZYjOOgSS4aOaPv9gxlkI2KRkN24kagbZnPZMnN8bZZyzw1rrLvwgpuRGv17Uz+hflosbR+SP6w==",
             "hasInstallScript": true,
             "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@swc/counter": "^0.1.3",
                 "@swc/types": "^0.1.17"
@@ -4309,6 +4292,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -4325,6 +4309,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -4341,6 +4326,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -4357,6 +4343,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -4373,6 +4360,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -4389,6 +4377,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -4405,6 +4394,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -4421,6 +4411,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -4437,6 +4428,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -4453,6 +4445,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -4461,13 +4454,17 @@
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
             "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-            "license": "Apache-2.0"
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true
         },
         "node_modules/@swc/types": {
             "version": "0.1.17",
             "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.17.tgz",
             "integrity": "sha512-V5gRru+aD8YVyCOMAjMpWR1Ui577DD5KSJsHP8RAxopAH22jFz6GZd/qxqjO6MJHQhcsjvjOFXyDhyLQUnMveQ==",
             "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@swc/counter": "^0.1.3"
             }
@@ -10894,19 +10891,6 @@
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "license": "MIT"
         },
-        "node_modules/uuid": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-            "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
-        },
         "node_modules/v8-compile-cache-lib": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -11032,29 +11016,6 @@
             "license": "MIT",
             "peerDependencies": {
                 "vite": ">= 2.7"
-            }
-        },
-        "node_modules/vite-plugin-top-level-await": {
-            "version": "1.4.4",
-            "resolved": "https://registry.npmjs.org/vite-plugin-top-level-await/-/vite-plugin-top-level-await-1.4.4.tgz",
-            "integrity": "sha512-QyxQbvcMkgt+kDb12m2P8Ed35Sp6nXP+l8ptGrnHV9zgYDUpraO0CPdlqLSeBqvY2DToR52nutDG7mIHuysdiw==",
-            "license": "MIT",
-            "dependencies": {
-                "@rollup/plugin-virtual": "^3.0.2",
-                "@swc/core": "^1.7.0",
-                "uuid": "^10.0.0"
-            },
-            "peerDependencies": {
-                "vite": ">=2.8"
-            }
-        },
-        "node_modules/vite-plugin-wasm": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/vite-plugin-wasm/-/vite-plugin-wasm-3.4.1.tgz",
-            "integrity": "sha512-ja3nSo2UCkVeitltJGkS3pfQHAanHv/DqGatdI39ja6McgABlpsZ5hVgl6wuR8Qx5etY3T5qgDQhOWzc5RReZA==",
-            "license": "MIT",
-            "peerDependencies": {
-                "vite": "^2 || ^3 || ^4 || ^5 || ^6"
             }
         },
         "node_modules/vitest": {
@@ -11454,9 +11415,7 @@
                 "@dfinity/agent": "^2.3.0",
                 "@dfinity/candid": "^2.3.0",
                 "@dfinity/principal": "^2.3.0",
-                "ic_vetkd_sdk_encrypted_maps": "^0.1.0",
-                "vite-plugin-top-level-await": "^1.4.4",
-                "vite-plugin-wasm": "^3.4.1"
+                "ic_vetkd_sdk_encrypted_maps": "^0.1.0"
             },
             "devDependencies": {
                 "@dfinity/identity": "^2.2.0",
@@ -11493,9 +11452,7 @@
                 "@dfinity/agent": "^2.3.0",
                 "@dfinity/candid": "^2.3.0",
                 "@dfinity/principal": "^2.3.0",
-                "@types/node": "^22.13.0",
-                "vite-plugin-top-level-await": "^1.4.4",
-                "vite-plugin-wasm": "^3.4.1"
+                "@types/node": "^22.13.0"
             },
             "devDependencies": {
                 "@dfinity/identity": "^2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11441,9 +11441,6 @@
                 "eslint": "^9.22.0",
                 "typescript": "^5.7.3",
                 "typescript-eslint": "8.27"
-            },
-            "peerDependencies": {
-                "ic-vetkd-cdk-utils": "^0.1.0"
             }
         },
         "sdk/ic_vetkd_sdk_key_manager_example": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11441,6 +11441,9 @@
                 "eslint": "^9.22.0",
                 "typescript": "^5.7.3",
                 "typescript-eslint": "8.27"
+            },
+            "peerDependencies": {
+                "ic_vetkd_sdk_utils": "^0.1.0"
             }
         },
         "sdk/ic_vetkd_sdk_key_manager_example": {

--- a/sdk/ic_vetkd_sdk_encrypted_maps_example/package.json
+++ b/sdk/ic_vetkd_sdk_encrypted_maps_example/package.json
@@ -12,9 +12,7 @@
         "@dfinity/agent": "^2.3.0",
         "@dfinity/candid": "^2.3.0",
         "@dfinity/principal": "^2.3.0",
-        "ic_vetkd_sdk_encrypted_maps": "^0.1.0",
-        "vite-plugin-top-level-await": "^1.4.4",
-        "vite-plugin-wasm": "^3.4.1"
+        "ic_vetkd_sdk_encrypted_maps": "^0.1.0"
     },
     "devDependencies": {
         "@dfinity/identity": "^2.2.0",
@@ -23,8 +21,8 @@
         "eslint": "^9.22",
         "fake-indexeddb": "^6.0.0",
         "isomorphic-fetch": "3.0.0",
-        "typescript-eslint": "8.27",
         "typescript": "^5.7.3",
+        "typescript-eslint": "8.27",
         "vite": "^6.1.2",
         "vitest": "^3.0.5"
     },

--- a/sdk/ic_vetkd_sdk_encrypted_maps_example/vite.config.ts
+++ b/sdk/ic_vetkd_sdk_encrypted_maps_example/vite.config.ts
@@ -1,7 +1,5 @@
 import { defineConfig } from 'vite';
 import path from 'path';
-import wasm from "vite-plugin-wasm";
-import topLevelAwait from "vite-plugin-top-level-await";
 
 export default defineConfig({
     build: {
@@ -17,15 +15,6 @@ export default defineConfig({
                 globals: {}
             }
         }
-    },
-    plugins: [
-        wasm(),
-        topLevelAwait()
-    ],
-    esbuild: {
-        supported: {
-            'top-level-await': true //browsers can handle top-level-await features
-        },
     },
     test: {
         environment: "happy-dom",

--- a/sdk/ic_vetkd_sdk_key_manager/package.json
+++ b/sdk/ic_vetkd_sdk_key_manager/package.json
@@ -8,16 +8,13 @@
     "main": "dist/index.umd.js",
     "module": "dist/index.es5.js",
     "typings": "dist/types/index.d.ts",
-    "peerDependencies": {
-        "ic-vetkd-cdk-utils": "^0.1.0"
-    },
     "license": "Apache-2.0",
     "dependencies": {
         "@dfinity/principal": "^2.3.0"
     },
     "devDependencies": {
-        "eslint": "^9.22.0",
         "@eslint/js": "^9.22.0",
+        "eslint": "^9.22.0",
         "typescript": "^5.7.3",
         "typescript-eslint": "8.27"
     },

--- a/sdk/ic_vetkd_sdk_key_manager/package.json
+++ b/sdk/ic_vetkd_sdk_key_manager/package.json
@@ -21,5 +21,8 @@
     "scripts": {
         "build": "tsc",
         "lint": "eslint"
+    },
+    "peerDependencies": {
+        "ic_vetkd_sdk_utils": "^0.1.0"
     }
 }

--- a/sdk/ic_vetkd_sdk_key_manager_example/package.json
+++ b/sdk/ic_vetkd_sdk_key_manager_example/package.json
@@ -15,9 +15,7 @@
     "@dfinity/agent": "^2.3.0",
     "@dfinity/candid": "^2.3.0",
     "@dfinity/principal": "^2.3.0",
-    "@types/node": "^22.13.0",
-    "vite-plugin-top-level-await": "^1.4.4",
-    "vite-plugin-wasm": "^3.4.1"
+    "@types/node": "^22.13.0"
   },
   "devDependencies": {
     "@dfinity/identity": "^2.2.0",
@@ -27,8 +25,8 @@
     "eslint": "^9.22.0",
     "happy-dom": "^17.0.0",
     "isomorphic-fetch": "^3.0.0",
-    "typescript-eslint": "8.27",
     "typescript": "^5.7.3",
+    "typescript-eslint": "8.27",
     "vite": "^6.1.2",
     "vitest": "^3.0.5"
   },

--- a/sdk/ic_vetkd_sdk_key_manager_example/vite.config.ts
+++ b/sdk/ic_vetkd_sdk_key_manager_example/vite.config.ts
@@ -1,7 +1,5 @@
 import { defineConfig } from 'vite';
 import path from 'path';
-import wasm from "vite-plugin-wasm";
-import topLevelAwait from "vite-plugin-top-level-await";
 
 export default defineConfig({
     build: {
@@ -17,15 +15,6 @@ export default defineConfig({
                 globals: {}
             }
         }
-    },
-    plugins: [
-        wasm(),
-        topLevelAwait()
-    ],
-    esbuild: {
-        supported: {
-            'top-level-await': true //browsers can handle top-level-await features
-        },
     },
     test: {
         environment: "happy-dom",


### PR DESCRIPTION
There were a few artifact plugins remaining from when we used WASM-based utils. They are removed in this PR, since they are not needed anymore.