### PR TITLE
feat: CRP-2759 access control trait

### DIFF
--- a/cdk/encrypted_maps/src/lib.rs
+++ b/cdk/encrypted_maps/src/lib.rs
@@ -24,12 +24,11 @@ use candid::Principal;
 use ic_stable_structures::memory_manager::VirtualMemory;
 use ic_stable_structures::storable::Blob;
 use ic_stable_structures::{DefaultMemoryImpl, StableBTreeMap};
-use std::cell::RefCell;
 use std::future::Future;
 
 use ic_vetkd_cdk_key_manager::KeyId;
 use ic_vetkd_cdk_types::{
-    AccessRights, ByteBuf, EncryptedMapValue, MapId, MapKey, MapName, TransportKey,
+    AccessControl, ByteBuf, EncryptedMapValue, MapId, MapKey, MapName, TransportKey,
 };
 
 // On a high level,
@@ -39,18 +38,14 @@ use ic_vetkd_cdk_types::{
 pub type VetKeyVerificationKey = ByteBuf;
 pub type VetKey = ByteBuf;
 
-thread_local! {
-    static ENCRYPTED_MAPS: RefCell<Option<EncryptedMaps>> = const { RefCell::new(None) };
-}
-
 type Memory = VirtualMemory<DefaultMemoryImpl>;
 
-pub struct EncryptedMaps {
-    pub key_manager: ic_vetkd_cdk_key_manager::KeyManager,
+pub struct EncryptedMaps<T: AccessControl> {
+    pub key_manager: ic_vetkd_cdk_key_manager::KeyManager<T>,
     pub mapkey_vals: StableBTreeMap<(KeyId, MapKey), EncryptedMapValue, Memory>,
 }
 
-impl EncryptedMaps {
+impl<T: AccessControl> EncryptedMaps<T> {
     /// Initializes the EncryptedMaps and the underlying KeyManager.
     /// Must be called before any other EncryptedMaps operations.
     pub fn init(
@@ -85,7 +80,7 @@ impl EncryptedMaps {
         &self,
         caller: Principal,
         key_id: KeyId,
-    ) -> Result<Vec<(Principal, AccessRights)>, String> {
+    ) -> Result<Vec<(Principal, T)>, String> {
         self.key_manager
             .get_shared_user_access_for_key(caller, key_id)
     }
@@ -98,8 +93,8 @@ impl EncryptedMaps {
         key_id: KeyId,
     ) -> Result<Vec<MapKey>, String> {
         match self.key_manager.get_user_rights(caller, key_id, caller)? {
-            Some(AccessRights::ReadWrite) | Some(AccessRights::ReadWriteManage) => Ok(()),
-            Some(AccessRights::Read) | None => Err("unauthorized".to_string()),
+            Some(a) if a.can_write() => Ok(()),
+            Some(_) | None => Err("unauthorized".to_string()),
         }?;
 
         let keys: Vec<_> = self
@@ -157,7 +152,7 @@ impl EncryptedMaps {
         result
     }
 
-    pub fn get_all_accessible_encrypted_maps(&self, caller: Principal) -> Vec<EncryptedMapData> {
+    pub fn get_all_accessible_encrypted_maps(&self, caller: Principal) -> Vec<EncryptedMapData<T>> {
         let mut result = Vec::new();
         for map_id in self.get_accessible_map_ids_iter(caller) {
             let keyvals = self
@@ -209,8 +204,8 @@ impl EncryptedMaps {
         encrypted_value: EncryptedMapValue,
     ) -> Result<Option<EncryptedMapValue>, String> {
         match self.key_manager.get_user_rights(caller, key_id, caller)? {
-            Some(AccessRights::ReadWrite) | Some(AccessRights::ReadWriteManage) => Ok(()),
-            Some(AccessRights::Read) | None => Err("unauthorized".to_string()),
+            Some(a) if a.can_write() => Ok(()),
+            Some(_) | None => Err("unauthorized".to_string()),
         }?;
 
         Ok(self.mapkey_vals.insert((key_id, key), encrypted_value))
@@ -224,8 +219,8 @@ impl EncryptedMaps {
         key: MapKey,
     ) -> Result<Option<EncryptedMapValue>, String> {
         match self.key_manager.get_user_rights(caller, key_id, caller)? {
-            Some(AccessRights::ReadWrite) | Some(AccessRights::ReadWriteManage) => Ok(()),
-            Some(AccessRights::Read) | None => Err("unauthorized".to_string()),
+            Some(a) if a.can_write() => Ok(()),
+            Some(_) | None => Err("unauthorized".to_string()),
         }?;
 
         Ok(self.mapkey_vals.remove(&(key_id, key)))
@@ -255,7 +250,7 @@ impl EncryptedMaps {
         caller: Principal,
         key_id: KeyId,
         user: Principal,
-    ) -> Result<Option<AccessRights>, String> {
+    ) -> Result<Option<T>, String> {
         self.key_manager.get_user_rights(caller, key_id, user)
     }
 
@@ -265,8 +260,8 @@ impl EncryptedMaps {
         caller: Principal,
         key_id: KeyId,
         user: Principal,
-        access_rights: AccessRights,
-    ) -> Result<Option<AccessRights>, String> {
+        access_rights: T,
+    ) -> Result<Option<T>, String> {
         self.key_manager
             .set_user_rights(caller, key_id, user, access_rights)
     }
@@ -277,17 +272,17 @@ impl EncryptedMaps {
         caller: Principal,
         key_id: KeyId,
         user: Principal,
-    ) -> Result<Option<AccessRights>, String> {
+    ) -> Result<Option<T>, String> {
         self.key_manager.remove_user(caller, key_id, user)
     }
 }
 
-#[derive(serde::Deserialize, candid::CandidType)]
-pub struct EncryptedMapData {
+#[derive(candid::CandidType)]
+pub struct EncryptedMapData<T: AccessControl> {
     pub map_owner: Principal,
     pub map_name: ByteBuf,
     pub keyvals: Vec<(ByteBuf, EncryptedMapValue)>,
-    pub access_control: Vec<(Principal, AccessRights)>,
+    pub access_control: Vec<(Principal, T)>,
 }
 
 #[cfg(feature = "expose-testing-api")]

--- a/cdk/encrypted_maps/src/lib.rs
+++ b/cdk/encrypted_maps/src/lib.rs
@@ -165,7 +165,7 @@ impl<T: AccessControl> EncryptedMaps<T> {
                 map_owner: map_id.0,
                 map_name: ByteBuf::from(map_id.1.as_ref().to_vec()),
                 keyvals,
-                access_control: self.get_shared_user_access_for_map(caller, map_id).unwrap(),
+                access_control: self.get_shared_user_access_for_map(caller, map_id).ok(),
             };
             result.push(map);
         }
@@ -282,7 +282,7 @@ pub struct EncryptedMapData<T: AccessControl> {
     pub map_owner: Principal,
     pub map_name: ByteBuf,
     pub keyvals: Vec<(ByteBuf, EncryptedMapValue)>,
-    pub access_control: Vec<(Principal, T)>,
+    pub access_control: Option<Vec<(Principal, T)>>,
 }
 
 #[cfg(feature = "expose-testing-api")]

--- a/cdk/encrypted_maps/src/lib.rs
+++ b/cdk/encrypted_maps/src/lib.rs
@@ -165,7 +165,9 @@ impl<T: AccessControl> EncryptedMaps<T> {
                 map_owner: map_id.0,
                 map_name: ByteBuf::from(map_id.1.as_ref().to_vec()),
                 keyvals,
-                access_control: self.get_shared_user_access_for_map(caller, map_id).ok(),
+                access_control: self
+                    .get_shared_user_access_for_map(caller, map_id)
+                    .unwrap_or_default(),
             };
             result.push(map);
         }
@@ -282,7 +284,7 @@ pub struct EncryptedMapData<T: AccessControl> {
     pub map_owner: Principal,
     pub map_name: ByteBuf,
     pub keyvals: Vec<(ByteBuf, EncryptedMapValue)>,
-    pub access_control: Option<Vec<(Principal, T)>>,
+    pub access_control: Vec<(Principal, T)>,
 }
 
 #[cfg(feature = "expose-testing-api")]

--- a/cdk/encrypted_maps/tests/tests.rs
+++ b/cdk/encrypted_maps/tests/tests.rs
@@ -523,7 +523,7 @@ fn can_get_owned_map_names() {
     }
 }
 
-fn random_encrypted_maps<R: Rng + CryptoRng>(rng: &mut R) -> EncryptedMaps {
+fn random_encrypted_maps<R: Rng + CryptoRng>(rng: &mut R) -> EncryptedMaps<AccessRights> {
     let memory_manager = MemoryManager::init(DefaultMemoryImpl::default());
     let (memory_id_encrypted_maps, memory_ids_key_manager) = random_unique_memory_ids(rng);
     let domain_separator_len = rng.random_range(0..32);

--- a/cdk/encrypted_maps/tests/tests.rs
+++ b/cdk/encrypted_maps/tests/tests.rs
@@ -405,14 +405,13 @@ fn can_access_map_values() {
                 assert_eq!(
                     BTreeMap::<Principal, AccessRights>::from_iter(
                         map.access_control
-                            .expect("should be able to retrieve access rights")
                             .into_iter()
                             .chain(std::iter::once((caller, access_rights)))
                     ),
                     BTreeMap::from_iter(authorized_users.clone().into_iter())
                 );
             } else {
-                assert_eq!(map.access_control, None);
+                assert_eq!(map.access_control, vec![]);
             }
         }
     }

--- a/cdk/encrypted_maps/tests/tests.rs
+++ b/cdk/encrypted_maps/tests/tests.rs
@@ -1,9 +1,7 @@
-use std::{
-    collections::{BTreeMap, HashSet},
-    iter::FromIterator,
-};
+use std::{collections::BTreeMap, iter::FromIterator};
 
 use assert_matches::assert_matches;
+use candid::Principal;
 use ic_stable_structures::{
     memory_manager::{MemoryId, MemoryManager},
     storable::Blob,
@@ -18,7 +16,7 @@ use rand::{CryptoRng, Rng};
 use strum::IntoEnumIterator;
 
 use ic_vetkd_cdk_encrypted_maps::EncryptedMaps;
-use ic_vetkd_cdk_types::AccessRights;
+use ic_vetkd_cdk_types::{AccessControl, AccessRights};
 
 #[test]
 fn can_init_memory() {
@@ -328,7 +326,7 @@ fn can_access_map_values() {
     let name = random_name(rng);
     let mut encrypted_maps = random_encrypted_maps(rng);
 
-    let mut authorized_users = vec![caller];
+    let mut authorized_users = vec![(caller, AccessRights::ReadWriteManage)];
     let mut keyvals = vec![];
 
     for _ in 0..3 {
@@ -349,14 +347,14 @@ fn can_access_map_values() {
                 ),
                 Ok(None)
             );
-            authorized_users.push(user_to_be_added);
+            authorized_users.push((user_to_be_added, access_rights));
         }
 
         keyvals.push((key.clone(), value));
     }
 
     for (key, value) in keyvals.clone() {
-        for user in authorized_users.iter() {
+        for (user, _access_rights) in authorized_users.iter() {
             assert_eq!(
                 encrypted_maps.get_encrypted_value(*user, (caller, name.clone()), key.clone()),
                 Ok(Some(value.clone()))
@@ -364,18 +362,18 @@ fn can_access_map_values() {
         }
     }
 
-    for added_user in authorized_users.clone() {
+    for (user, access_rights) in authorized_users.clone() {
         let expected_map = BTreeMap::from_iter(keyvals.clone().into_iter());
         let computed_map_single = BTreeMap::from_iter(
             encrypted_maps
-                .get_encrypted_values_for_map(added_user, (caller, name.clone()))
+                .get_encrypted_values_for_map(user, (caller, name.clone()))
                 .expect("failed to obtain values")
                 .into_iter(),
         );
         assert_eq!(expected_map, computed_map_single);
 
-        let all_values = encrypted_maps.get_all_accessible_encrypted_values(added_user);
-        let all_maps = encrypted_maps.get_all_accessible_encrypted_maps(added_user);
+        let all_values = encrypted_maps.get_all_accessible_encrypted_values(user);
+        let all_maps = encrypted_maps.get_all_accessible_encrypted_maps(user);
         assert_eq!(all_values.len(), 1);
         assert_eq!(
             all_values,
@@ -403,14 +401,19 @@ fn can_access_map_values() {
         assert_eq!(expected_map, computed_map_wildcard);
 
         for map in all_maps {
-            assert_eq!(
-                map.access_control
-                    .iter()
-                    .map(|(p, _a)| *p)
-                    .chain(std::iter::once(caller))
-                    .collect::<HashSet<_>>(),
-                authorized_users.clone().into_iter().collect::<HashSet<_>>()
-            );
+            if access_rights.can_get_user_rights() {
+                assert_eq!(
+                    BTreeMap::<Principal, AccessRights>::from_iter(
+                        map.access_control
+                            .expect("should be able to retrieve access rights")
+                            .into_iter()
+                            .chain(std::iter::once((caller, access_rights)))
+                    ),
+                    BTreeMap::from_iter(authorized_users.clone().into_iter())
+                );
+            } else {
+                assert_eq!(map.access_control, None);
+            }
         }
     }
 }

--- a/cdk/encrypted_maps_example/src/lib.rs
+++ b/cdk/encrypted_maps_example/src/lib.rs
@@ -14,7 +14,7 @@ type MapId = (Principal, ByteBuf);
 thread_local! {
     static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> =
         RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
-        static ENCRYPTED_MAPS: RefCell<EncryptedMaps> = RefCell::new(EncryptedMaps::init("encrypted_maps", id_to_memory(0), id_to_memory(1), id_to_memory(2), id_to_memory(3)));
+        static ENCRYPTED_MAPS: RefCell<EncryptedMaps<AccessRights>> = RefCell::new(EncryptedMaps::init("encrypted_maps", id_to_memory(0), id_to_memory(1), id_to_memory(2), id_to_memory(3)));
 }
 
 #[query]
@@ -78,7 +78,7 @@ fn get_all_accessible_encrypted_values() -> Vec<(MapId, Vec<(ByteBuf, EncryptedM
 }
 
 #[query]
-fn get_all_accessible_encrypted_maps() -> Vec<EncryptedMapData> {
+fn get_all_accessible_encrypted_maps() -> Vec<EncryptedMapData<AccessRights>> {
     ENCRYPTED_MAPS.with_borrow(|encrypted_maps| {
         encrypted_maps.get_all_accessible_encrypted_maps(ic_cdk::caller())
     })

--- a/cdk/key_manager/src/lib.rs
+++ b/cdk/key_manager/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //! The **KeyManager** consists of two primary components:
 //!
-//! 1. **Access Control Map** (`access_control`): Maps `(Caller, KeyId)` to `AccessRights`, defining permissions for each user.
+//! 1. **Access Control Map** (`access_control`): Maps `(Caller, KeyId)` to `T`, defining permissions for each user.
 //! 2. **Shared Keys Map** (`shared_keys`): Tracks which users have access to shared keys.
 
 use candid::Principal;
@@ -29,7 +29,7 @@ use ic_cdk::api::management_canister::main::CanisterId;
 use ic_stable_structures::memory_manager::VirtualMemory;
 use ic_stable_structures::storable::Blob;
 use ic_stable_structures::{DefaultMemoryImpl, StableBTreeMap, StableCell, Storable};
-use ic_vetkd_cdk_types::{AccessRights, ByteBuf, KeyName, TransportKey};
+use ic_vetkd_cdk_types::{AccessControl, ByteBuf, KeyName, TransportKey};
 use std::future::Future;
 use std::str::FromStr;
 
@@ -61,13 +61,13 @@ thread_local! {
 
 type Memory = VirtualMemory<DefaultMemoryImpl>;
 
-pub struct KeyManager {
+pub struct KeyManager<T: AccessControl> {
     pub domain_separator: StableCell<String, Memory>,
-    pub access_control: StableBTreeMap<(Caller, KeyId), AccessRights, Memory>,
+    pub access_control: StableBTreeMap<(Caller, KeyId), T, Memory>,
     pub shared_keys: StableBTreeMap<(KeyId, Caller), (), Memory>,
 }
 
-impl KeyManager {
+impl<T: AccessControl> KeyManager<T> {
     /// Initializes the KeyManager with stable storage.
     /// This function must be called exactly once before any other KeyManager operation can be invoked.
     pub fn init(
@@ -100,7 +100,7 @@ impl KeyManager {
         &self,
         caller: Principal,
         key_id: KeyId,
-    ) -> Result<Vec<(Principal, AccessRights)>, String> {
+    ) -> Result<Vec<(Principal, T)>, String> {
         self.ensure_user_can_read(caller, key_id)?;
 
         let users: Vec<_> = self
@@ -188,7 +188,7 @@ impl KeyManager {
         caller: Principal,
         key_id: KeyId,
         user: Principal,
-    ) -> Result<Option<AccessRights>, String> {
+    ) -> Result<Option<T>, String> {
         self.ensure_user_can_read(caller, key_id)?;
         Ok(self.ensure_user_can_read(user, key_id).ok())
     }
@@ -200,8 +200,8 @@ impl KeyManager {
         caller: Principal,
         key_id: KeyId,
         user: Principal,
-        access_rights: AccessRights,
-    ) -> Result<Option<AccessRights>, String> {
+        access_rights: T,
+    ) -> Result<Option<T>, String> {
         self.ensure_user_can_manage(caller, key_id)?;
 
         if caller == key_id.0 && caller == user {
@@ -218,7 +218,7 @@ impl KeyManager {
         caller: Principal,
         key_id: KeyId,
         user: Principal,
-    ) -> Result<Option<AccessRights>, String> {
+    ) -> Result<Option<T>, String> {
         self.ensure_user_can_manage(caller, key_id)?;
 
         if caller == user && caller == key_id.0 {
@@ -231,10 +231,10 @@ impl KeyManager {
 
     /// Ensures that a user has read access to a key before proceeding.
     /// Returns an error if the user is not authorized.
-    fn ensure_user_can_read(&self, user: Principal, key_id: KeyId) -> Result<AccessRights, String> {
+    fn ensure_user_can_read(&self, user: Principal, key_id: KeyId) -> Result<T, String> {
         let is_owner = user == key_id.0;
         if is_owner {
-            return Ok(AccessRights::ReadWriteManage);
+            return Ok(T::owner_rights());
         }
 
         let has_shared_access = self.access_control.get(&(user, key_id));
@@ -247,21 +247,15 @@ impl KeyManager {
 
     /// Ensures that a user has management access to a key before proceeding.
     /// Returns an error if the user is not authorized.
-    fn ensure_user_can_manage(
-        &self,
-        user: Principal,
-        key_id: KeyId,
-    ) -> Result<AccessRights, String> {
+    fn ensure_user_can_manage(&self, user: Principal, key_id: KeyId) -> Result<T, String> {
         let is_owner = user == key_id.0;
         if is_owner {
-            return Ok(AccessRights::ReadWriteManage);
+            return Ok(T::owner_rights());
         }
 
         let has_shared_access = self.access_control.get(&(user, key_id));
         match has_shared_access {
-            Some(access_rights) if access_rights == AccessRights::ReadWriteManage => {
-                Ok(access_rights)
-            }
+            Some(access_rights) if access_rights.can_set_user_rights() => Ok(access_rights),
             _ => Err("unauthorized".to_string()),
         }
     }

--- a/cdk/key_manager/tests/tests.rs
+++ b/cdk/key_manager/tests/tests.rs
@@ -271,13 +271,13 @@ fn add_or_remove_user_by_unauthorized_fails() {
 #[test]
 fn can_instantiate_two_key_managers() {
     let memory_manager = MemoryManager::init(DefaultMemoryImpl::default());
-    let key_manager_1 = KeyManager::init(
+    let key_manager_1 = KeyManager::<AccessRights>::init(
         "key_manager_1",
         memory_manager.get(MemoryId::new(0)),
         memory_manager.get(MemoryId::new(1)),
         memory_manager.get(MemoryId::new(2)),
     );
-    let key_manager_2 = KeyManager::init(
+    let key_manager_2 = KeyManager::<AccessRights>::init(
         "key_manager_2",
         memory_manager.get(MemoryId::new(3)),
         memory_manager.get(MemoryId::new(4)),
@@ -287,11 +287,11 @@ fn can_instantiate_two_key_managers() {
     std::hint::black_box((key_manager_1, key_manager_2));
 }
 
-fn random_key_manager<R: Rng + CryptoRng>(rng: &mut R) -> KeyManager {
+fn random_key_manager<R: Rng + CryptoRng>(rng: &mut R) -> KeyManager<AccessRights> {
     let memory_manager = MemoryManager::init(DefaultMemoryImpl::default());
     let (_memory_id_encrypted_maps, memory_ids_key_manager) = random_unique_memory_ids(rng);
     let domain_separator_len = rng.random_range(0..32);
-    KeyManager::init(
+    KeyManager::<AccessRights>::init(
         &random_utf8_string(rng, domain_separator_len),
         memory_manager.get(MemoryId::new(memory_ids_key_manager[0])),
         memory_manager.get(MemoryId::new(memory_ids_key_manager[1])),

--- a/cdk/key_manager_example/src/lib.rs
+++ b/cdk/key_manager_example/src/lib.rs
@@ -13,7 +13,7 @@ type Memory = VirtualMemory<DefaultMemoryImpl>;
 thread_local! {
     static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> =
         RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
-    static KEY_MANAGER: RefCell<KeyManager> = RefCell::new(KeyManager::init("key_manager", id_to_memory(0), id_to_memory(1), id_to_memory(2)));
+    static KEY_MANAGER: RefCell<KeyManager<AccessRights>> = RefCell::new(KeyManager::init("key_manager", id_to_memory(0), id_to_memory(1), id_to_memory(2)));
 }
 
 #[query]

--- a/examples/password_manager_with_metadata/backend/src/lib.rs
+++ b/examples/password_manager_with_metadata/backend/src/lib.rs
@@ -69,7 +69,7 @@ type StableMetadataMap = StableBTreeMap<(MapOwner, MapName, MapKey), PasswordMet
 thread_local! {
     static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> =
         RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
-    static ENCRYPTED_MAPS: RefCell<EncryptedMaps> = RefCell::new(EncryptedMaps::init(
+    static ENCRYPTED_MAPS: RefCell<EncryptedMaps<AccessRights>> = RefCell::new(EncryptedMaps::init(
         "password_manager",
         MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(0))),
         MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(1))),


### PR DESCRIPTION
Improves flexibility of access control by adding an `AccessControl` trait, which allows to construct custom access control rights, e.g., with a time delay for access or more fine-grained access rights. Also enforces that the caller must satisfy the condition of  `can_get_user_rights()` with `AccessRights::ReadWriteManage` (previously read rights sufficed) to retrieve other users' rights in the `AccessRights` implementation.