### PR TITLE
chore: replace chainkey testing canister with the pocket IC's vetkd

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           set -eExuo pipefail
           export CARGO_TERM_COLOR=always # ensure output has colors
-          cargo build --release --target wasm32-unknown-unknown --features expose-testing-api -p ic-vetkeys-manager-canister -p ic-vetkeys-encrypted-maps-canister
+          cargo build --release --target wasm32-unknown-unknown -p ic-vetkeys-manager-canister -p ic-vetkeys-encrypted-maps-canister
           cargo test
   cargo-test-backend-darwin:
     runs-on: macos-15
@@ -49,5 +49,5 @@ jobs:
         run: |
           set -eExuo pipefail
           export CARGO_TERM_COLOR=always # ensure output has colors
-          cargo build --release --target wasm32-unknown-unknown --features expose-testing-api -p ic-vetkeys-manager-canister -p ic-vetkeys-encrypted-maps-canister
+          cargo build --release --target wasm32-unknown-unknown -p ic-vetkeys-manager-canister -p ic-vetkeys-encrypted-maps-canister
           cargo test

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -25,16 +25,6 @@ jobs:
         run: |
           set -eExuo pipefail
           npm install
-          pushd backend/rs/canisters/ic_vetkeys_encrypted_maps_canister
-          dfx start --background --replica
-          dfx deploy
-          eval $(make export-cmd)
-          popd
-          pushd backend/rs/canisters/ic_vetkeys_manager_canister
-          dfx start --background --replica
-          dfx deploy
-          eval $(make export-cmd)
-          popd
           cd frontend/ic_vetkeys
           npm run build
           npm run test
@@ -50,16 +40,6 @@ jobs:
         run: |
           set -eExuo pipefail
           npm install
-          pushd backend/rs/canisters/ic_vetkeys_encrypted_maps_canister
-          dfx start --background --replica
-          dfx deploy
-          eval $(make export-cmd)
-          popd
-          pushd backend/rs/canisters/ic_vetkeys_manager_canister
-          dfx start --background --replica
-          dfx deploy
-          eval $(make export-cmd)
-          popd
           cd frontend/ic_vetkeys
           npm run build
           npm run test

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -26,13 +26,13 @@ jobs:
           set -eExuo pipefail
           npm install
           pushd backend/rs/canisters/ic_vetkeys_encrypted_maps_canister
-          dfx start --background
-          make mock
+          dfx start --background --replica
+          dfx deploy
           eval $(make export-cmd)
           popd
           pushd backend/rs/canisters/ic_vetkeys_manager_canister
-          dfx start --background
-          make mock
+          dfx start --background --replica
+          dfx deploy
           eval $(make export-cmd)
           popd
           cd frontend/ic_vetkeys
@@ -51,13 +51,13 @@ jobs:
           set -eExuo pipefail
           npm install
           pushd backend/rs/canisters/ic_vetkeys_encrypted_maps_canister
-          dfx start --background
-          make mock
+          dfx start --background --replica
+          dfx deploy
           eval $(make export-cmd)
           popd
           pushd backend/rs/canisters/ic_vetkeys_manager_canister
-          dfx start --background
-          make mock
+          dfx start --background --replica
+          dfx deploy
           eval $(make export-cmd)
           popd
           cd frontend/ic_vetkeys

--- a/.github/workflows/provision-darwin.sh
+++ b/.github/workflows/provision-darwin.sh
@@ -10,7 +10,7 @@ brew install nodejs
 
 # Install DFINITY SDK.
 curl --location --output install-dfx.sh "https://raw.githubusercontent.com/dfinity/sdk/master/public/install-dfxvm.sh"
-DFX_VERSION=${DFX_VERSION:=0.25.0} DFXVM_INIT_YES=true bash install-dfx.sh
+DFX_VERSION=${DFX_VERSION:=0.26.1} DFXVM_INIT_YES=true bash install-dfx.sh
 rm install-dfx.sh
 echo "$HOME/Library/Application Support/org.dfinity.dfx/bin" >> $GITHUB_PATH
 source "$HOME/Library/Application Support/org.dfinity.dfx/env"

--- a/.github/workflows/provision-linux.sh
+++ b/.github/workflows/provision-linux.sh
@@ -10,7 +10,7 @@ sudo apt-get install nodejs
 
 # Install DFINITY SDK.
 wget --output-document install-dfx.sh "https://raw.githubusercontent.com/dfinity/sdk/master/public/install-dfxvm.sh"
-DFX_VERSION=${DFX_VERSION:=0.25.0} DFXVM_INIT_YES=true bash install-dfx.sh
+DFX_VERSION=${DFX_VERSION:=0.26.1} DFXVM_INIT_YES=true bash install-dfx.sh
 rm install-dfx.sh
 echo "$HOME/.local/share/dfx/bin" >>$GITHUB_PATH
 source "$HOME/.local/share/dfx/env"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1153,6 +1153,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-management-canister-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90253c6ac92f9a0b548a53a02c2d29dfa0f04a6c1ae919b86a6f54d4767d78b9"
+dependencies = [
+ "candid",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
 name = "ic-stable-structures"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1949,9 +1960,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "pocket-ic"
-version = "7.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd672d6b262731dccae40cb561e4c578709ea9987fbf649377d51077bf16db3"
+checksum = "1d0dee25e0f699db883fa2228b18b6e86ae874a0f538dd362aef70679ca5cc6d"
 dependencies = [
  "backoff",
  "base64 0.13.1",
@@ -1959,6 +1970,7 @@ dependencies = [
  "flate2",
  "hex",
  "ic-certification 3.0.3",
+ "ic-management-canister-types",
  "ic-transport-types 0.39.3",
  "reqwest",
  "schemars",
@@ -1970,6 +1982,7 @@ dependencies = [
  "slog",
  "strum",
  "strum_macros",
+ "tempfile",
  "thiserror 2.0.12",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ ic-cdk-macros = "0.17.1"
 ic-stable-structures = "0.6.8"
 ic-vetkd-utils = { version = "0.1.0", git = "https://github.com/dfinity/ic.git" }
 lazy_static = "1.5.0"
-pocket-ic = "7.0.0"
+pocket-ic = "9.0.0"
 rand = "0.9.0"
 rand_chacha = "0.9.0"
 serde = "1.0.217"

--- a/backend/mo/ic_vetkeys/src/key_manager/KeyManager.mo
+++ b/backend/mo/ic_vetkeys/src/key_manager/KeyManager.mo
@@ -51,7 +51,6 @@ module {
     public class KeyManager<T>(domainSeparator : Text, accessRightsOperations : Types.AccessControlOperations<T>) {
         public var accessControl : OrderedMap.Map<Principal, [(KeyId, T)]> = accessControlMapOps().empty();
         public var sharedKeys : OrderedMap.Map<KeyId, [Principal]> = sharedKeysMapOps().empty();
-        public var managementCanisterPrincipalText = "aaaaa-aa";
         let domainSeparatorBytes = Text.encodeUtf8(domainSeparator);
 
         // Get accessible shared key IDs for a caller
@@ -106,7 +105,7 @@ module {
                 key_id = bls12_381TestKey1();
             };
 
-            let (reply) = await (actor (managementCanisterPrincipalText) : VetkdSystemApi).vetkd_public_key(request);
+            let (reply) = await (actor ("aaaaa-aa") : VetkdSystemApi).vetkd_public_key(request);
             reply.public_key;
         };
 
@@ -129,7 +128,7 @@ module {
                         transport_public_key = transportKey;
                     };
 
-                    let (reply) = await (actor (managementCanisterPrincipalText) : VetkdSystemApi).vetkd_derive_key(request);
+                    let (reply) = await (actor ("aaaaa-aa") : VetkdSystemApi).vetkd_derive_key(request);
                     #ok(reply.encrypted_key);
                 };
             };

--- a/backend/mo/ic_vetkeys/src/key_manager/KeyManager.mo
+++ b/backend/mo/ic_vetkeys/src/key_manager/KeyManager.mo
@@ -340,6 +340,6 @@ module {
 
     // Helper function for BLS12-381 test key
     func bls12_381TestKey1() : { curve : { #bls12_381_g2 }; name : Text } {
-        { curve = #bls12_381_g2; name = "insecure_text_key_1" };
+        { curve = #bls12_381_g2; name = "dfx_test_key" };
     };
 };

--- a/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister/Cargo.toml
+++ b/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister/Cargo.toml
@@ -26,6 +26,3 @@ pocket-ic = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 reqwest = "0.12.12"
-
-[features]
-expose-testing-api = ["ic-vetkeys/expose-testing-api"]

--- a/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister/Makefile
+++ b/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister/Makefile
@@ -10,35 +10,6 @@ compile-wasm:
 extract-candid: compile-wasm
 	candid-extractor $(ROOT_DIR)/target/wasm32-unknown-unknown/release/ic_vetkeys_encrypted_maps_canister.wasm > ic_vetkeys_encrypted_maps_canister.did
 
-.PHONY: compile-wasm-test
-.SILENT: compile-wasm-test
-compile-wasm-test:
-	cargo build --release --target wasm32-unknown-unknown --features expose-testing-api
-
-.PHONY: deploy-test
-.SILENT: deploy-test
-deploy-test: compile-wasm-test
-	dfx canister create chainkey_testing_canister && \
-	dfx canister create ic_vetkeys_encrypted_maps_canister && \
-	dfx build chainkey_testing_canister && \
-	dfx canister install --upgrade-unchanged --mode auto chainkey_testing_canister && \
-	dfx canister install --upgrade-unchanged --mode auto --wasm $(ROOT_DIR)/target/wasm32-unknown-unknown/release/ic_vetkeys_encrypted_maps_canister.wasm ic_vetkeys_encrypted_maps_canister
-
-.PHONY: mock
-.SILENT: mock
-mock: deploy-test
-	VETKD_MOCK_CANISTER_ID=$(shell dfx canister id chainkey_testing_canister); \
-	echo "Changing to using mock canister instead of management canister for vetkd to "$${VETKD_MOCK_CANISTER_ID}""; \
-    CMD="dfx canister call ic_vetkeys_encrypted_maps_canister set_vetkd_testing_canister_id '(principal "\"$${VETKD_MOCK_CANISTER_ID}\"")'"; \
-	eval "$${CMD}"
-
-.PHONY: export-cmd
-.SILENT: export-cmd
-export-cmd:
-	CANISTER_ID_IC_VETKEYS_ENCRYPTED_MAPS_CANISTER=$(shell dfx canister id ic_vetkeys_encrypted_maps_canister); \
-	CMD="export CANISTER_ID_IC_VETKEYS_ENCRYPTED_MAPS_CANISTER=$${CANISTER_ID_IC_VETKEYS_ENCRYPTED_MAPS_CANISTER}"; \
-	echo "$${CMD}"
-
 .PHONY: clean
 .SILENT: clean
 clean:

--- a/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister/dfx.json
+++ b/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister/dfx.json
@@ -4,11 +4,6 @@
       "candid": "ic_vetkeys_encrypted_maps_canister.did",
       "package": "ic-vetkeys-encrypted-maps-canister",
       "type": "rust"
-    },
-    "chainkey_testing_canister": {
-      "type": "custom",
-      "candid": "https://github.com/dfinity/chainkey-testing-canister/releases/download/v0.2.0/chainkey_testing_canister.did",
-      "wasm": "https://github.com/dfinity/chainkey-testing-canister/releases/download/v0.2.0/chainkey_testing_canister.wasm.gz"
     }
   },
   "networks": {

--- a/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister/dfx.json
+++ b/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister/dfx.json
@@ -11,5 +11,6 @@
       "bind": "localhost:8000",
       "type": "ephemeral"
     }
-  }
+  },
+  "output_env_file": ".env"
 }

--- a/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister/src/lib.rs
+++ b/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister/src/lib.rs
@@ -220,12 +220,6 @@ fn remove_user(
     })
 }
 
-#[cfg(feature = "expose-testing-api")]
-#[update]
-fn set_vetkd_testing_canister_id(vetkd_testing_canister: Principal) {
-    ic_vetkeys::key_manager::set_vetkd_testing_canister_id(vetkd_testing_canister)
-}
-
 fn bytebuf_to_blob(buf: ByteBuf) -> Result<Blob<32>, String> {
     Blob::try_from(buf.as_ref()).map_err(|_| "too large input".to_string())
 }

--- a/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister/tests/tests.rs
+++ b/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister/tests/tests.rs
@@ -174,13 +174,8 @@ impl TestEnvironment {
             .with_application_subnet()
             .with_ii_subnet()
             .with_fiduciary_subnet()
+            .with_nonmainnet_features(true)
             .build();
-
-        let vetkd_mock_canister_id = pic.create_canister();
-        pic.add_cycles(vetkd_mock_canister_id, 2_000_000_000_000);
-
-        let vetkd_mock_wasm_bytes = load_vetkd_mock_canister_wasm();
-        pic.install_canister(vetkd_mock_canister_id, vetkd_mock_wasm_bytes, vec![], None);
 
         let example_canister_id = pic.create_canister();
         pic.add_cycles(example_canister_id, 2_000_000_000_000);
@@ -197,14 +192,6 @@ impl TestEnvironment {
             principal_0: random_self_authenticating_principal(rng),
             principal_1: random_self_authenticating_principal(rng),
         };
-
-        // Set the vetkd mock canister ID in the example canister, requires the
-        // `--features expose-testing-api`.
-        let _: () = env.update(
-            vetkd_mock_canister_id,
-            "set_vetkd_testing_canister_id",
-            encode_one(vetkd_mock_canister_id).unwrap(),
-        );
 
         env
     }
@@ -247,18 +234,9 @@ fn load_key_manager_example_canister_wasm() -> Vec<u8> {
     );
     let wasm_path = Path::new(&wasm_path_string);
     let wasm_bytes = std::fs::read(wasm_path).expect(
-        "wasm does not exist - run `cargo build --release --target wasm32-unknown-unknown --features expose-testing-api`",
+        "wasm does not exist - run `cargo build --release --target wasm32-unknown-unknown`",
     );
     wasm_bytes
-}
-
-fn load_vetkd_mock_canister_wasm() -> Vec<u8> {
-    let wasm_url = "https://github.com/dfinity/chainkey-testing-canister/releases/download/v0.2.0/chainkey_testing_canister.wasm.gz";
-    reqwest::blocking::get(wasm_url)
-        .unwrap()
-        .bytes()
-        .unwrap()
-        .to_vec()
 }
 
 fn random_transport_key<R: Rng + CryptoRng>(rng: &mut R) -> TransportSecretKey {

--- a/backend/rs/canisters/ic_vetkeys_manager_canister/Cargo.toml
+++ b/backend/rs/canisters/ic_vetkeys_manager_canister/Cargo.toml
@@ -26,7 +26,3 @@ pocket-ic = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 reqwest = "0.12.12"
-
-[features]
-expose-testing-api = ["ic-vetkeys/expose-testing-api"]
-

--- a/backend/rs/canisters/ic_vetkeys_manager_canister/Makefile
+++ b/backend/rs/canisters/ic_vetkeys_manager_canister/Makefile
@@ -10,28 +10,6 @@ compile-wasm:
 extract-candid: compile-wasm
 	candid-extractor $(ROOT_DIR)/target/wasm32-unknown-unknown/release/ic_vetkeys_manager_canister.wasm > ic_vetkeys_manager_canister.did
 
-.PHONY: compile-wasm-test
-.SILENT: compile-wasm-test
-compile-wasm-test:
-	cargo build --release --target wasm32-unknown-unknown --features expose-testing-api
-
-.PHONY: deploy-test
-.SILENT: deploy-test
-deploy-test: compile-wasm-test
-	dfx canister create chainkey_testing_canister && \
-	dfx canister create ic_vetkeys_manager_canister && \
-	dfx build chainkey_testing_canister && \
-	dfx canister install chainkey_testing_canister && \
-	dfx canister install --wasm $(ROOT_DIR)/target/wasm32-unknown-unknown/release/ic_vetkeys_manager_canister.wasm ic_vetkeys_manager_canister
-
-.PHONY: mock
-.SILENT: mock
-mock: deploy-test
-	VETKD_MOCK_CANISTER_ID=$(shell dfx canister id chainkey_testing_canister); \
-	echo "Changing to using mock canister instead of management canister for vetkd to "$${VETKD_MOCK_CANISTER_ID}""; \
-    CMD="dfx canister call ic_vetkeys_manager_canister set_vetkd_testing_canister_id '(principal "\"$${VETKD_MOCK_CANISTER_ID}\"")'"; \
-	eval "$${CMD}"
-
 .PHONY: export-cmd
 .SILENT: export-cmd
 export-cmd:

--- a/backend/rs/canisters/ic_vetkeys_manager_canister/dfx.json
+++ b/backend/rs/canisters/ic_vetkeys_manager_canister/dfx.json
@@ -4,11 +4,6 @@
         "candid": "ic_vetkeys_manager_canister.did",
         "package": "ic-vetkeys-manager-canister",
         "type": "rust"
-      },
-      "chainkey_testing_canister": {
-        "type": "custom",
-        "candid": "https://github.com/dfinity/chainkey-testing-canister/releases/download/v0.2.0/chainkey_testing_canister.did",
-        "wasm": "https://github.com/dfinity/chainkey-testing-canister/releases/download/v0.2.0/chainkey_testing_canister.wasm.gz"
       }
     }
   }

--- a/backend/rs/canisters/ic_vetkeys_manager_canister/dfx.json
+++ b/backend/rs/canisters/ic_vetkeys_manager_canister/dfx.json
@@ -5,5 +5,6 @@
         "package": "ic-vetkeys-manager-canister",
         "type": "rust"
       }
-    }
+    },
+    "output_env_file": ".env"
   }

--- a/backend/rs/canisters/ic_vetkeys_manager_canister/src/lib.rs
+++ b/backend/rs/canisters/ic_vetkeys_manager_canister/src/lib.rs
@@ -91,12 +91,6 @@ fn remove_user(
     KEY_MANAGER.with_borrow_mut(|km| km.remove_user(ic_cdk::caller(), key_id, user))
 }
 
-#[cfg(feature = "expose-testing-api")]
-#[update]
-fn set_vetkd_testing_canister_id(vetkd_testing_canister: Principal) {
-    ic_vetkeys::key_manager::set_vetkd_testing_canister_id(vetkd_testing_canister)
-}
-
 fn bytebuf_to_blob(buf: ByteBuf) -> Result<Blob<32>, String> {
     Blob::try_from(buf.as_ref()).map_err(|_| "too large input".to_string())
 }

--- a/backend/rs/canisters/ic_vetkeys_manager_canister/tests/tests.rs
+++ b/backend/rs/canisters/ic_vetkeys_manager_canister/tests/tests.rs
@@ -178,13 +178,8 @@ impl TestEnvironment {
             .with_application_subnet()
             .with_ii_subnet()
             .with_fiduciary_subnet()
+            .with_nonmainnet_features(true)
             .build();
-
-        let vetkd_mock_canister_id = pic.create_canister();
-        pic.add_cycles(vetkd_mock_canister_id, 2_000_000_000_000);
-
-        let vetkd_mock_wasm_bytes = load_vetkd_mock_canister_wasm();
-        pic.install_canister(vetkd_mock_canister_id, vetkd_mock_wasm_bytes, vec![], None);
 
         let example_canister_id = pic.create_canister();
         pic.add_cycles(example_canister_id, 2_000_000_000_000);
@@ -201,14 +196,6 @@ impl TestEnvironment {
             principal_0: random_self_authenticating_principal(rng),
             principal_1: random_self_authenticating_principal(rng),
         };
-
-        // Set the vetkd mock canister ID in the example canister, requires the
-        // `--features expose-testing-api`.
-        let _: () = env.update(
-            vetkd_mock_canister_id,
-            "set_vetkd_testing_canister_id",
-            encode_one(vetkd_mock_canister_id).unwrap(),
-        );
 
         env
     }
@@ -251,18 +238,9 @@ fn load_key_manager_example_canister_wasm() -> Vec<u8> {
     );
     let wasm_path = Path::new(&wasm_path_string);
     let wasm_bytes = std::fs::read(wasm_path).expect(
-"wasm does not exist - run `cargo build --release --target wasm32-unknown-unknown --features expose-testing-api`",
+"wasm does not exist - run `cargo build --release --target wasm32-unknown-unknown`",
 );
     wasm_bytes
-}
-
-fn load_vetkd_mock_canister_wasm() -> Vec<u8> {
-    let wasm_url = "https://github.com/dfinity/chainkey-testing-canister/releases/download/v0.2.0/chainkey_testing_canister.wasm.gz";
-    reqwest::blocking::get(wasm_url)
-        .unwrap()
-        .bytes()
-        .unwrap()
-        .to_vec()
 }
 
 fn random_transport_key<R: Rng + CryptoRng>(rng: &mut R) -> TransportSecretKey {

--- a/backend/rs/ic_vetkeys/Cargo.toml
+++ b/backend/rs/ic_vetkeys/Cargo.toml
@@ -33,6 +33,3 @@ pocket-ic = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 strum = "0.26.3"
-
-[features]
-expose-testing-api = []

--- a/examples/basic_ibe/README.md
+++ b/examples/basic_ibe/README.md
@@ -37,8 +37,6 @@ Run the local deployment script, which starts the local development environment 
 bash deploy_locally.sh
 ```
 
-Note that currently in a local deployment, the [chainkey *testing* canister](https://github.com/dfinity/chainkey-testing-canister) is used to mock the VetKD protocol.
-
 ## Example Components
 
 ### Backend

--- a/examples/basic_ibe/backend/Cargo.toml
+++ b/examples/basic_ibe/backend/Cargo.toml
@@ -21,6 +21,3 @@ serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_cbor = { workspace = true }
 serde_with = { workspace = true }
-
-[features]
-expose-testing-api = []

--- a/examples/basic_ibe/backend/Makefile
+++ b/examples/basic_ibe/backend/Makefile
@@ -11,35 +11,6 @@ compile-wasm:
 extract-candid: compile-wasm
 	candid-extractor $(ROOT_DIR)/target/wasm32-unknown-unknown/release/ic_vetkd_example_basic_ibe_backend.wasm > backend.did
 
-.PHONY: compile-wasm-test
-.SILENT: compile-wasm-test
-compile-wasm-test:
-	cargo build --release --target wasm32-unknown-unknown --features expose-testing-api
-
-.PHONY: deploy-test
-.SILENT: deploy-test
-deploy-test: compile-wasm-test
-	dfx canister create chainkey_testing_canister && \
-	dfx canister create basic_ibe && \
-	dfx build chainkey_testing_canister && \
-	dfx canister install --upgrade-unchanged --mode auto chainkey_testing_canister && \
-	dfx canister install --upgrade-unchanged --mode auto --wasm $(ROOT_DIR)/target/wasm32-unknown-unknown/release/ic_vetkd_example_basic_ibe_backend.wasm basic_ibe
-
-.PHONY: mock
-.SILENT: mock
-mock: deploy-test
-	CANISTER_ID_VETKD_MOCK=$(shell dfx canister id chainkey_testing_canister); \
-	echo "Changing to using mock canister instead of management canister for vetkd to "$${CANISTER_ID_VETKD_MOCK}""; \
-    CMD="dfx canister call basic_ibe set_vetkd_testing_canister_id '(principal "\"$${CANISTER_ID_VETKD_MOCK}\"")'"; \
-	eval "$${CMD}"
-
-.PHONY: export-cmd
-.SILENT: export-cmd
-export-cmd:
-	CANISTER_ID_BASIC_IBE=$(shell dfx canister id basic_ibe); \
-	CMD="export CANISTER_ID_BASIC_IBE=$${CANISTER_ID_BASIC_IBE}"; \
-	echo "$${CMD}"
-
 .PHONY: clean
 .SILENT: clean
 clean:

--- a/examples/basic_ibe/deploy_locally.sh
+++ b/examples/basic_ibe/deploy_locally.sh
@@ -8,11 +8,6 @@ dfx --version >> /dev/null
 # Run `dfx` if it is not already running.
 dfx ping &> /dev/null || dfx start --background --clean --replica >> /dev/null
 
-# Deploy the backend canister.
-pushd backend
-    dfx deploy
-popd
-
 # Deploy the Internet Identity canister and export the environment variable of
 # the canister ID.
 dfx deps pull && dfx deps init && dfx deps deploy &&
@@ -29,5 +24,5 @@ pushd frontend
     npm run build
 popd
 
-# Deploy the frontend canister.
-dfx deploy www
+# Deploy canisters.
+dfx deploy

--- a/examples/basic_ibe/deploy_locally.sh
+++ b/examples/basic_ibe/deploy_locally.sh
@@ -6,14 +6,11 @@ set -e
 dfx --version >> /dev/null
 
 # Run `dfx` if it is not already running.
-dfx ping &> /dev/null || dfx start --background --clean >> /dev/null
+dfx ping &> /dev/null || dfx start --background --clean --replica >> /dev/null
 
-# Deploy the chainkey testing canister and the backend canister, and replace the
-# management canister ID for the VetKD interface with the chainkey testing
-# canister. Then, export the environment variable of the canister ID.
+# Deploy the backend canister.
 pushd backend
-    make mock &&
-    eval $(make export-cmd)
+    dfx deploy
 popd
 
 # Deploy the Internet Identity canister and export the environment variable of

--- a/examples/basic_ibe/deploy_locally.sh
+++ b/examples/basic_ibe/deploy_locally.sh
@@ -6,7 +6,7 @@ set -e
 dfx --version >> /dev/null
 
 # Run `dfx` if it is not already running.
-dfx ping &> /dev/null || dfx start --background --clean --replica >> /dev/null
+dfx ping &> /dev/null || dfx start --background --clean >> /dev/null
 
 # Deploy the Internet Identity canister and export the environment variable of
 # the canister ID.

--- a/examples/basic_ibe/dfx.json
+++ b/examples/basic_ibe/dfx.json
@@ -11,11 +11,6 @@
         }
       ]
     },
-    "chainkey_testing_canister": {
-      "type": "custom",
-      "candid": "https://github.com/dfinity/chainkey-testing-canister/releases/download/v0.2.0/chainkey_testing_canister.did",
-      "wasm": "https://github.com/dfinity/chainkey-testing-canister/releases/download/v0.2.0/chainkey_testing_canister.wasm.gz"
-    },
     "internet-identity": {
       "type": "pull",
       "id": "rdmx6-jaaaa-aaaaa-aaadq-cai"

--- a/examples/basic_timelock_ibe/backend/Cargo.toml
+++ b/examples/basic_timelock_ibe/backend/Cargo.toml
@@ -24,6 +24,3 @@ serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_cbor = { workspace = true }
 serde_with = { workspace = true }
-
-[features]
-expose-testing-api = []

--- a/examples/basic_timelock_ibe/backend/Makefile
+++ b/examples/basic_timelock_ibe/backend/Makefile
@@ -10,35 +10,6 @@ compile-wasm:
 extract-candid: compile-wasm
 	candid-extractor $(ROOT_DIR)/target/wasm32-unknown-unknown/release/ic_vetkd_example_basic_timelock_ibe_backend.wasm > backend.did
 
-.PHONY: compile-wasm-test
-.SILENT: compile-wasm-test
-compile-wasm-test:
-	cargo build --release --target wasm32-unknown-unknown --features expose-testing-api
-
-.PHONY: deploy-test
-.SILENT: deploy-test
-deploy-test: compile-wasm-test
-	dfx canister create chainkey_testing_canister && \
-	dfx canister create basic_timelock_ibe && \
-	dfx build chainkey_testing_canister && \
-	dfx canister install --upgrade-unchanged --mode auto chainkey_testing_canister && \
-	dfx canister install --upgrade-unchanged --mode auto --wasm $(ROOT_DIR)/target/wasm32-unknown-unknown/release/ic_vetkd_example_basic_timelock_ibe_backend.wasm basic_timelock_ibe
-
-.PHONY: mock
-.SILENT: mock
-mock: deploy-test
-	CANISTER_ID_VETKD_MOCK=$(shell dfx canister id chainkey_testing_canister); \
-	echo "Changing to using mock canister instead of management canister for vetkd to "$${CANISTER_ID_VETKD_MOCK}""; \
-    CMD="dfx canister call basic_timelock_ibe set_vetkd_testing_canister_id '(principal "\"$${CANISTER_ID_VETKD_MOCK}\"")'"; \
-	eval "$${CMD}"
-
-.PHONY: export-cmd
-.SILENT: export-cmd
-export-cmd:
-	CANISTER_ID_BASIC_TIMELOCK_IBE=$(shell dfx canister id basic_timelock_ibe); \
-	CMD="export CANISTER_ID_BASIC_TIMELOCK_IBE=$${CANISTER_ID_BASIC_TIMELOCK_IBE}"; \
-	echo "$${CMD}"
-
 .PHONY: clean
 .SILENT: clean
 clean:

--- a/examples/basic_timelock_ibe/backend/src/lib.rs
+++ b/examples/basic_timelock_ibe/backend/src/lib.rs
@@ -34,9 +34,6 @@ thread_local! {
     static VETKD_ROOT_IBE_PUBLIC_KEY: RefCell<Option<VetKeyPublicKey>> =  const { RefCell::new(None) };
 
     static BID_COUNTER: RefCell<BidCounter> = RefCell::new(0);
-
-    #[cfg(feature = "expose-testing-api")]
-    static CANISTER_ID_VETKD_MOCK: RefCell<Option<Principal>> = const { RefCell::new(None) };
 }
 
 const DOMAIN_SEPARATOR: &str = "basic_timelock_ibe_example_dapp";
@@ -97,7 +94,7 @@ async fn get_root_ibe_public_key() -> VetKeyPublicKey {
     let request = VetKDPublicKeyRequest {
         canister_id: None,
         context: DOMAIN_SEPARATOR.as_bytes().to_vec(),
-        key_id: bls12_381_test_key_1(),
+        key_id: bls12_381_dfx_test_key(),
     };
 
     let (result,) = ic_cdk::api::call::call::<_, (VetKDPublicKeyReply,)>(
@@ -297,7 +294,7 @@ async fn decrypt_bids(
     let request = VetKDDeriveKeyRequest {
         context: DOMAIN_SEPARATOR.as_bytes().to_vec(),
         input: lot_id.to_le_bytes().to_vec(),
-        key_id: bls12_381_test_key_1(),
+        key_id: bls12_381_dfx_test_key(),
         transport_public_key: transport_secret_key.public_key().to_vec(),
     };
 
@@ -364,29 +361,15 @@ fn is_authenticated() -> Result<(), String> {
     }
 }
 
-fn bls12_381_test_key_1() -> VetKDKeyId {
+fn bls12_381_dfx_test_key() -> VetKDKeyId {
     VetKDKeyId {
         curve: VetKDCurve::Bls12_381_G2,
-        name: "insecure_test_key_1".to_string(),
+        name: "dfx_test_key".to_string(),
     }
 }
 
 fn vetkd_system_api_canister_id() -> CanisterId {
-    #[cfg(feature = "expose-testing-api")]
-    {
-        if let Some(canister_id) = CANISTER_ID_VETKD_MOCK.with(|cell| cell.borrow().clone()) {
-            return canister_id;
-        }
-    }
     CanisterId::from_str(CANISTER_ID_VETKD_SYSTEM_API).expect("failed to create canister ID")
-}
-
-#[cfg(feature = "expose-testing-api")]
-#[update]
-fn set_vetkd_testing_canister_id(vetkd_testing_canister: Principal) {
-    CANISTER_ID_VETKD_MOCK.with(|cell| {
-        *cell.borrow_mut() = Some(vetkd_testing_canister);
-    });
 }
 
 // In the following, we register a custom getrandom implementation because

--- a/examples/basic_timelock_ibe/deploy_locally.sh
+++ b/examples/basic_timelock_ibe/deploy_locally.sh
@@ -6,14 +6,11 @@ set -e
 dfx --version >> /dev/null
 
 # Run `dfx` if it is not already running.
-dfx ping &> /dev/null || dfx start --background --clean >> /dev/null
+dfx ping &> /dev/null || dfx start --background --clean --replica >> /dev/null
 
-# Deploy the chainkey testing canister and the backend canister, and replace the
-# management canister ID for the VetKD interface with the chainkey testing
-# canister. Then, export the environment variable of the canister ID.
+# Deploy the backend canister.
 pushd backend
-    make mock &&
-    eval $(make export-cmd)
+    dfx deploy
 popd
 
 # Deploy the Internet Identity canister and export the environment variable of

--- a/examples/basic_timelock_ibe/deploy_locally.sh
+++ b/examples/basic_timelock_ibe/deploy_locally.sh
@@ -8,11 +8,6 @@ dfx --version >> /dev/null
 # Run `dfx` if it is not already running.
 dfx ping &> /dev/null || dfx start --background --clean --replica >> /dev/null
 
-# Deploy the backend canister.
-pushd backend
-    dfx deploy
-popd
-
 # Deploy the Internet Identity canister and export the environment variable of
 # the canister ID.
 dfx deps pull && dfx deps init && dfx deps deploy &&
@@ -30,5 +25,7 @@ pushd frontend
     npm run build
 popd
 
-# Deploy the frontend canister.
-dfx deploy www
+# Deploy canisters.
+pushd backend
+    dfx deploy
+popd

--- a/examples/basic_timelock_ibe/deploy_locally.sh
+++ b/examples/basic_timelock_ibe/deploy_locally.sh
@@ -6,7 +6,7 @@ set -e
 dfx --version >> /dev/null
 
 # Run `dfx` if it is not already running.
-dfx ping &> /dev/null || dfx start --background --clean --replica >> /dev/null
+dfx ping &> /dev/null || dfx start --background --clean >> /dev/null
 
 # Deploy the Internet Identity canister and export the environment variable of
 # the canister ID.

--- a/examples/basic_timelock_ibe/dfx.json
+++ b/examples/basic_timelock_ibe/dfx.json
@@ -11,11 +11,6 @@
         }
       ]
     },
-    "chainkey_testing_canister": {
-      "type": "custom",
-      "candid": "https://github.com/dfinity/chainkey-testing-canister/releases/download/v0.2.0/chainkey_testing_canister.did",
-      "wasm": "https://github.com/dfinity/chainkey-testing-canister/releases/download/v0.2.0/chainkey_testing_canister.wasm.gz"
-    },
     "internet-identity": {
       "type": "pull",
       "id": "rdmx6-jaaaa-aaaaa-aaadq-cai"

--- a/examples/password_manager/deploy_locally.sh
+++ b/examples/password_manager/deploy_locally.sh
@@ -5,6 +5,9 @@ set -e
 # Check that `dfx` is installed.
 dfx --version >> /dev/null
 
+# Run `dfx` if it is not already running.
+dfx ping &> /dev/null || dfx start --background --clean >> /dev/null
+
 # Deploy the Internet Identity canister and export the environment variable of
 # the canister ID.
 dfx deps pull && dfx deps init && dfx deps deploy &&
@@ -12,8 +15,6 @@ dfx deps pull && dfx deps init && dfx deps deploy &&
 
 # Deploy the backend canister.
 pushd ../../backend/rs/canisters/ic_vetkeys_encrypted_maps_canister
-    # Run `dfx` if it is not already running.
-    dfx ping &> /dev/null || dfx start --background --clean >> /dev/null
     dfx deploy
 popd
 

--- a/examples/password_manager/deploy_locally.sh
+++ b/examples/password_manager/deploy_locally.sh
@@ -6,14 +6,11 @@ set -e
 dfx --version >> /dev/null
 
 # Run `dfx` if it is not already running.
-dfx ping &> /dev/null || dfx start --background --clean >> /dev/null
+dfx ping &> /dev/null || dfx start --background --clean --replica >> /dev/null
 
-# Deploy the chainkey testing canister and the backend canister, and replace the
-# management canister ID for the VetKD interface with the chainkey testing
-# canister. Then, export the environment variable of the canister ID.
+# Deploy the backend canister.
 pushd ../../backend/rs/canisters/ic_vetkeys_encrypted_maps_canister
-    make mock &&
-    eval $(make export-cmd)
+    dfx deploy
 popd
 
 # Deploy the Internet Identity canister and export the environment variable of

--- a/examples/password_manager/deploy_locally.sh
+++ b/examples/password_manager/deploy_locally.sh
@@ -8,15 +8,15 @@ dfx --version >> /dev/null
 # Run `dfx` if it is not already running.
 dfx ping &> /dev/null || dfx start --background --clean --replica >> /dev/null
 
-# Deploy the backend canister.
-pushd ../../backend/rs/canisters/ic_vetkeys_encrypted_maps_canister
-    dfx deploy
-popd
-
 # Deploy the Internet Identity canister and export the environment variable of
 # the canister ID.
 dfx deps pull && dfx deps init && dfx deps deploy &&
     export CANISTER_ID_INTERNET_IDENTITY=rdmx6-jaaaa-aaaaa-aaadq-cai
+
+# Deploy the backend canister.
+pushd ../../backend/rs/canisters/ic_vetkeys_encrypted_maps_canister
+    dfx deploy
+popd
 
 # Store environment variables for the frontend.
 echo "DFX_NETWORK=$DFX_NETWORK" > frontend/.env

--- a/examples/password_manager/deploy_locally.sh
+++ b/examples/password_manager/deploy_locally.sh
@@ -5,9 +5,6 @@ set -e
 # Check that `dfx` is installed.
 dfx --version >> /dev/null
 
-# Run `dfx` if it is not already running.
-dfx ping &> /dev/null || dfx start --background --clean >> /dev/null
-
 # Deploy the Internet Identity canister and export the environment variable of
 # the canister ID.
 dfx deps pull && dfx deps init && dfx deps deploy &&
@@ -15,6 +12,8 @@ dfx deps pull && dfx deps init && dfx deps deploy &&
 
 # Deploy the backend canister.
 pushd ../../backend/rs/canisters/ic_vetkeys_encrypted_maps_canister
+    # Run `dfx` if it is not already running.
+    dfx ping &> /dev/null || dfx start --background --clean >> /dev/null
     dfx deploy
 popd
 

--- a/examples/password_manager/deploy_locally.sh
+++ b/examples/password_manager/deploy_locally.sh
@@ -6,7 +6,7 @@ set -e
 dfx --version >> /dev/null
 
 # Run `dfx` if it is not already running.
-dfx ping &> /dev/null || dfx start --background --clean --replica >> /dev/null
+dfx ping &> /dev/null || dfx start --background --clean >> /dev/null
 
 # Deploy the Internet Identity canister and export the environment variable of
 # the canister ID.

--- a/examples/password_manager/dfx.json
+++ b/examples/password_manager/dfx.json
@@ -5,11 +5,6 @@
         "package": "ic-vetkeys-encrypted-maps-canister",
         "type": "rust"
       },
-      "chainkey_testing_canister": {
-        "type": "custom",
-        "candid": "https://github.com/dfinity/chainkey-testing-canister/releases/download/v0.2.0/chainkey_testing_canister.did",
-        "wasm": "https://github.com/dfinity/chainkey-testing-canister/releases/download/v0.2.0/chainkey_testing_canister.wasm.gz"
-      },
       "internet-identity": {
         "type": "pull",
         "id": "rdmx6-jaaaa-aaaaa-aaadq-cai"

--- a/examples/password_manager/dfx.json
+++ b/examples/password_manager/dfx.json
@@ -18,11 +18,5 @@
         ],
         "type": "assets"
       }
-    },
-    "networks": {
-      "local": {
-        "bind": "localhost:8000",
-        "type": "ephemeral"
-      }
     }
   }

--- a/examples/password_manager_with_metadata/backend/Cargo.toml
+++ b/examples/password_manager_with_metadata/backend/Cargo.toml
@@ -19,6 +19,3 @@ ic-stable-structures = { workspace = true }
 ic-vetkeys = { path = "../../../backend/rs/ic_vetkeys" }
 serde = { workspace = true }
 serde_cbor = { workspace = true }
-
-[features]
-expose-testing-api = ["ic-vetkeys/expose-testing-api"]

--- a/examples/password_manager_with_metadata/backend/Makefile
+++ b/examples/password_manager_with_metadata/backend/Makefile
@@ -11,35 +11,6 @@ compile-wasm:
 extract-candid: compile-wasm
 	candid-extractor $(ROOT_DIR)/target/wasm32-unknown-unknown/release/ic_vetkd_example_password_manager_with_metadata_backend.wasm > backend.did
 
-.PHONY: compile-wasm-test
-.SILENT: compile-wasm-test
-compile-wasm-test:
-	cargo build --release --target wasm32-unknown-unknown --features expose-testing-api
-
-.PHONY: deploy-test
-.SILENT: deploy-test
-deploy-test: compile-wasm-test
-	dfx canister create chainkey_testing_canister && \
-	dfx canister create password_manager_with_metadata && \
-	dfx build chainkey_testing_canister && \
-	dfx canister install --upgrade-unchanged --mode auto chainkey_testing_canister && \
-	dfx canister install --upgrade-unchanged --mode auto --wasm $(ROOT_DIR)/target/wasm32-unknown-unknown/release/ic_vetkd_example_password_manager_with_metadata_backend.wasm password_manager_with_metadata
-
-.PHONY: mock
-.SILENT: mock
-mock: deploy-test
-	SCHNORR_MOCK_CANISTER_ID=$(shell dfx canister id chainkey_testing_canister); \
-	echo "Changing to using mock canister instead of management canister for vetkd to "$${SCHNORR_MOCK_CANISTER_ID}""; \
-    CMD="dfx canister call password_manager_with_metadata set_vetkd_testing_canister_id '(principal "\"$${SCHNORR_MOCK_CANISTER_ID}\"")'"; \
-	eval "$${CMD}"
-
-.PHONY: export-cmd
-.SILENT: export-cmd
-export-cmd:
-	CANISTER_ID_PASSWORD_MANAGER_WITH_METADATA=$(shell dfx canister id password_manager_with_metadata); \
-	CMD="export CANISTER_ID_PASSWORD_MANAGER_WITH_METADATA=$${CANISTER_ID_PASSWORD_MANAGER_WITH_METADATA}"; \
-	echo "$${CMD}"
-
 .PHONY: clean
 .SILENT: clean
 clean:

--- a/examples/password_manager_with_metadata/backend/src/lib.rs
+++ b/examples/password_manager_with_metadata/backend/src/lib.rs
@@ -261,12 +261,6 @@ fn remove_user(
     })
 }
 
-#[cfg(feature = "expose-testing-api")]
-#[update]
-fn set_vetkd_testing_canister_id(vetkd_testing_canister: Principal) {
-    ic_vetkeys::key_manager::set_vetkd_testing_canister_id(vetkd_testing_canister)
-}
-
 fn bytebuf_to_blob(buf: ByteBuf) -> Result<Blob<32>, String> {
     Blob::try_from(buf.as_ref()).map_err(|_| "too large input".to_string())
 }

--- a/examples/password_manager_with_metadata/deploy_locally.sh
+++ b/examples/password_manager_with_metadata/deploy_locally.sh
@@ -8,11 +8,6 @@ dfx --version >> /dev/null
 # Run `dfx` if it is not already running.
 dfx ping &> /dev/null || dfx start --background --clean --replica >> /dev/null
 
-# Deploy the backend canister.
-pushd backend
-    dfx deploy
-popd
-
 # Deploy the Internet Identity canister and export the environment variable of
 # the canister ID.
 dfx deps pull && dfx deps init && dfx deps deploy &&
@@ -29,5 +24,5 @@ pushd frontend
     npm run build
 popd
 
-# Deploy the frontend canister.
-dfx deploy www
+# Deploy canisters.
+dfx deploy

--- a/examples/password_manager_with_metadata/deploy_locally.sh
+++ b/examples/password_manager_with_metadata/deploy_locally.sh
@@ -6,14 +6,11 @@ set -e
 dfx --version >> /dev/null
 
 # Run `dfx` if it is not already running.
-dfx ping &> /dev/null || dfx start --background --clean >> /dev/null
+dfx ping &> /dev/null || dfx start --background --clean --replica >> /dev/null
 
-# Deploy the chainkey testing canister and the backend canister, and replace the
-# management canister ID for the VetKD interface with the chainkey testing
-# canister. Then, export the environment variable of the canister ID.
+# Deploy the backend canister.
 pushd backend
-    make mock &&
-    eval $(make export-cmd)
+    dfx deploy
 popd
 
 # Deploy the Internet Identity canister and export the environment variable of

--- a/examples/password_manager_with_metadata/deploy_locally.sh
+++ b/examples/password_manager_with_metadata/deploy_locally.sh
@@ -6,7 +6,7 @@ set -e
 dfx --version >> /dev/null
 
 # Run `dfx` if it is not already running.
-dfx ping &> /dev/null || dfx start --background --clean --replica >> /dev/null
+dfx ping &> /dev/null || dfx start --background --clean >> /dev/null
 
 # Deploy the Internet Identity canister and export the environment variable of
 # the canister ID.

--- a/examples/password_manager_with_metadata/dfx.json
+++ b/examples/password_manager_with_metadata/dfx.json
@@ -11,11 +11,6 @@
         }
       ]
     },
-    "chainkey_testing_canister": {
-      "type": "custom",
-      "candid": "https://github.com/dfinity/chainkey-testing-canister/releases/download/v0.2.0/chainkey_testing_canister.did",
-      "wasm": "https://github.com/dfinity/chainkey-testing-canister/releases/download/v0.2.0/chainkey_testing_canister.wasm.gz"
-    },
     "internet-identity": {
       "type": "pull",
       "id": "rdmx6-jaaaa-aaaaa-aaadq-cai"

--- a/frontend/ic_vetkeys/package.json
+++ b/frontend/ic_vetkeys/package.json
@@ -46,9 +46,9 @@
         "make:docs": "mkdir -p $(git rev-parse --show-toplevel)/docs/tools && typedoc --out $(git rev-parse --show-toplevel)/docs",
         "prettier": "prettier --write .",
         "prettier-check": "prettier --check .",
-        "test": "npm run test:deploy && export $(cat $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test1.env $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test2.env | xargs) && vitest",
-        "test:deploy": "npm run test:deploy_key_manager_canister && npm run test:deploy_encrypted_maps_canister",
-        "test:deploy_key_manager_canister": "cd $(git rev-parse --show-toplevel)/backend/rs/canisters/ic_vetkeys_manager_canister && dfx start --clean --background && dfx deploy && grep CANISTER_ID .env > $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test1.env",
-        "test:deploy_encrypted_maps_canister": "cd $(git rev-parse --show-toplevel)/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister && dfx start --clean --background && dfx deploy && grep CANISTER_ID .env > $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test2.env"
+        "test": "npm run test:deploy_all && export $(cat .test1.env .test2.env | xargs) && vitest",
+        "test:deploy_all": "npm run test:deploy_key_manager_canister && npm run test:deploy_encrypted_maps_canister",
+        "test:deploy_key_manager_canister": "cd $(git rev-parse --show-toplevel)/backend/rs/canisters/ic_vetkeys_manager_canister && dfx start --clean --background; dfx deploy && grep CANISTER_ID .env > $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test1.env",
+        "test:deploy_encrypted_maps_canister": "cd $(git rev-parse --show-toplevel)/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister && dfx start --clean --background; dfx deploy && grep CANISTER_ID .env > $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test2.env"
     }
 }

--- a/frontend/ic_vetkeys/package.json
+++ b/frontend/ic_vetkeys/package.json
@@ -48,7 +48,7 @@
         "prettier-check": "prettier --check .",
         "test": "npm run test:deploy && export $(cat $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test1.env $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test2.env | xargs) && vitest",
         "test:deploy": "npm run test:deploy_key_manager_canister && npm run test:deploy_encrypted_maps_canister",
-        "test:deploy_key_manager_canister": "cd $(git rev-parse --show-toplevel)/backend/rs/canisters/ic_vetkeys_manager_canister && dfx start --clean --background --replica; dfx deploy && grep CANISTER_ID .env > $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test1.env",
-        "test:deploy_encrypted_maps_canister": "cd $(git rev-parse --show-toplevel)/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister && dfx start --clean --background --replica; dfx deploy && grep CANISTER_ID .env > $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test2.env"
+        "test:deploy_key_manager_canister": "cd $(git rev-parse --show-toplevel)/backend/rs/canisters/ic_vetkeys_manager_canister && dfx start --clean --background --replica; wait 30; dfx deploy && grep CANISTER_ID .env > $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test1.env",
+        "test:deploy_encrypted_maps_canister": "cd $(git rev-parse --show-toplevel)/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister && dfx start --clean --background --replica; wait 30; dfx deploy && grep CANISTER_ID .env > $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test2.env"
     }
 }

--- a/frontend/ic_vetkeys/package.json
+++ b/frontend/ic_vetkeys/package.json
@@ -46,6 +46,9 @@
         "make:docs": "mkdir -p $(git rev-parse --show-toplevel)/docs/tools && typedoc --out $(git rev-parse --show-toplevel)/docs",
         "prettier": "prettier --write .",
         "prettier-check": "prettier --check .",
-        "test": "vitest"
+        "test": "npm run test:deploy && export $(cat $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test1.env $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test2.env | xargs) && vitest",
+        "test:deploy": "npm run test:deploy_key_manager_canister && npm run test:deploy_encrypted_maps_canister",
+        "test:deploy_key_manager_canister": "cd $(git rev-parse --show-toplevel)/backend/rs/canisters/ic_vetkeys_manager_canister && dfx deploy && grep CANISTER_ID .env > $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test1.env",
+        "test:deploy_encrypted_maps_canister": "cd $(git rev-parse --show-toplevel)/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister && dfx deploy && grep CANISTER_ID .env > $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test2.env"
     }
 }

--- a/frontend/ic_vetkeys/package.json
+++ b/frontend/ic_vetkeys/package.json
@@ -48,7 +48,7 @@
         "prettier-check": "prettier --check .",
         "test": "npm run test:deploy && export $(cat $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test1.env $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test2.env | xargs) && vitest",
         "test:deploy": "npm run test:deploy_key_manager_canister && npm run test:deploy_encrypted_maps_canister",
-        "test:deploy_key_manager_canister": "cd $(git rev-parse --show-toplevel)/backend/rs/canisters/ic_vetkeys_manager_canister && dfx start --clean --background; dfx deploy && grep CANISTER_ID .env > $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test1.env",
-        "test:deploy_encrypted_maps_canister": "cd $(git rev-parse --show-toplevel)/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister && dfx start --clean --background; dfx deploy && grep CANISTER_ID .env > $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test2.env"
+        "test:deploy_key_manager_canister": "cd $(git rev-parse --show-toplevel)/backend/rs/canisters/ic_vetkeys_manager_canister && dfx start --clean --background --replica; dfx deploy && grep CANISTER_ID .env > $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test1.env",
+        "test:deploy_encrypted_maps_canister": "cd $(git rev-parse --show-toplevel)/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister && dfx start --clean --background --replica; dfx deploy && grep CANISTER_ID .env > $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test2.env"
     }
 }

--- a/frontend/ic_vetkeys/package.json
+++ b/frontend/ic_vetkeys/package.json
@@ -48,7 +48,7 @@
         "prettier-check": "prettier --check .",
         "test": "npm run test:deploy && export $(cat $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test1.env $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test2.env | xargs) && vitest",
         "test:deploy": "npm run test:deploy_key_manager_canister && npm run test:deploy_encrypted_maps_canister",
-        "test:deploy_key_manager_canister": "cd $(git rev-parse --show-toplevel)/backend/rs/canisters/ic_vetkeys_manager_canister && dfx start --clean --background --replica; wait 30; dfx deploy && grep CANISTER_ID .env > $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test1.env",
-        "test:deploy_encrypted_maps_canister": "cd $(git rev-parse --show-toplevel)/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister && dfx start --clean --background --replica; wait 30; dfx deploy && grep CANISTER_ID .env > $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test2.env"
+        "test:deploy_key_manager_canister": "cd $(git rev-parse --show-toplevel)/backend/rs/canisters/ic_vetkeys_manager_canister && dfx start --clean --background && dfx deploy && grep CANISTER_ID .env > $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test1.env",
+        "test:deploy_encrypted_maps_canister": "cd $(git rev-parse --show-toplevel)/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister && dfx start --clean --background && dfx deploy && grep CANISTER_ID .env > $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test2.env"
     }
 }

--- a/frontend/ic_vetkeys/package.json
+++ b/frontend/ic_vetkeys/package.json
@@ -48,7 +48,7 @@
         "prettier-check": "prettier --check .",
         "test": "npm run test:deploy && export $(cat $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test1.env $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test2.env | xargs) && vitest",
         "test:deploy": "npm run test:deploy_key_manager_canister && npm run test:deploy_encrypted_maps_canister",
-        "test:deploy_key_manager_canister": "cd $(git rev-parse --show-toplevel)/backend/rs/canisters/ic_vetkeys_manager_canister && dfx deploy && grep CANISTER_ID .env > $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test1.env",
-        "test:deploy_encrypted_maps_canister": "cd $(git rev-parse --show-toplevel)/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister && dfx deploy && grep CANISTER_ID .env > $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test2.env"
+        "test:deploy_key_manager_canister": "cd $(git rev-parse --show-toplevel)/backend/rs/canisters/ic_vetkeys_manager_canister && dfx start --clean --background; dfx deploy && grep CANISTER_ID .env > $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test1.env",
+        "test:deploy_encrypted_maps_canister": "cd $(git rev-parse --show-toplevel)/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister && dfx start --clean --background; dfx deploy && grep CANISTER_ID .env > $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test2.env"
     }
 }


### PR DESCRIPTION
This PR also adds an automatic canister deployment step in `npm run test` s.t. the manual set up of the canisters in order to be able to run the frontend tests is not needed anymore.