### PR TITLE
chore: adapt frontend library `package.json` to be better suitable for publishing

### DIFF
--- a/examples/basic_ibe/frontend/package.json
+++ b/examples/basic_ibe/frontend/package.json
@@ -11,9 +11,6 @@
     "preview": "vite preview",
     "lint": "eslint"
   },
-  "peerDependencies": {
-    "ic_vetkeys": "^0.1.0"
-  },
   "devDependencies": {
     "@eslint/js": "^9.24.0",
     "@rollup/plugin-typescript": "^12.1.2",
@@ -25,5 +22,8 @@
   "dependencies": {
     "@dfinity/auth-client": "^2.4.1",
     "@dfinity/principal": "^2.4.1"
+  },
+  "peerDependencies": {
+    "@dfinity/vetkeys": "^0.1.0"
   }
 }

--- a/examples/basic_ibe/frontend/src/main.ts
+++ b/examples/basic_ibe/frontend/src/main.ts
@@ -7,7 +7,7 @@ import {
   EncryptedVetKey,
   VetKey,
   IdentityBasedEncryptionCiphertext,
-} from "ic_vetkeys";
+} from "@dfinity/vetkeys";
 import {
   Inbox,
   _SERVICE,

--- a/examples/basic_timelock_ibe/frontend/package.json
+++ b/examples/basic_timelock_ibe/frontend/package.json
@@ -11,9 +11,6 @@
     "preview": "vite preview",
     "lint": "eslint"
   },
-  "peerDependencies": {
-    "ic_vetkeys": "^0.1.0"
-  },
   "devDependencies": {
     "@eslint/js": "^9.24.0",
     "@rollup/plugin-typescript": "^12.1.2",
@@ -25,5 +22,8 @@
   "dependencies": {
     "@dfinity/auth-client": "^2.4.1",
     "@dfinity/principal": "^2.4.1"
+  },
+  "peerDependencies": {
+    "@dfinity/vetkeys": "^0.1.0"
   }
 }

--- a/examples/basic_timelock_ibe/frontend/src/main.ts
+++ b/examples/basic_timelock_ibe/frontend/src/main.ts
@@ -4,7 +4,7 @@ import { Principal } from "@dfinity/principal";
 import {
   DerivedPublicKey,
   IdentityBasedEncryptionCiphertext,
-} from "ic_vetkeys";
+} from "@dfinity/vetkeys";
 import {
   _SERVICE,
   LotInformation,

--- a/examples/password_manager/frontend/package.json
+++ b/examples/password_manager/frontend/package.json
@@ -11,9 +11,6 @@
     "prettier-check": "prettier --check .",
     "preview": "vite preview"
   },
-  "peerDependencies": {
-    "ic_vetkeys": "^0.1.0"
-  },
   "devDependencies": {
     "@rollup/plugin-typescript": "^12.1.2",
     "@tsconfig/svelte": "^5.0.4",
@@ -40,5 +37,8 @@
     "svelte-spa-router": "^4.0.1",
     "tailwindcss": "^3.0.17",
     "typewriter-editor": "^0.9.4"
+  },
+  "peerDependencies": {
+    "@dfinity/vetkeys": "^0.1.0"
   }
 }

--- a/examples/password_manager/frontend/src/components/EditPassword.svelte
+++ b/examples/password_manager/frontend/src/components/EditPassword.svelte
@@ -16,7 +16,7 @@
     import Spinner from "./Spinner.svelte";
     import { onDestroy } from "svelte";
     import { Principal } from "@dfinity/principal";
-    import type { AccessRights } from "ic_vetkeys/tools";
+    import type { AccessRights } from "@dfinity/vetkeys/tools";
 
     export let currentRoute = "";
     const unsubscribe = location.subscribe((value) => {

--- a/examples/password_manager/frontend/src/components/SharingEditor.svelte
+++ b/examples/password_manager/frontend/src/components/SharingEditor.svelte
@@ -9,7 +9,7 @@
     } from "../store/vaults";
     import { addNotification, showError } from "../store/notifications";
     import { Principal } from "@dfinity/principal";
-    import type { AccessRights } from "ic_vetkeys/tools";
+    import type { AccessRights } from "@dfinity/vetkeys/tools";
 
     export let editedVault: VaultModel;
     export let canManage = false;

--- a/examples/password_manager/frontend/src/components/Vault.svelte
+++ b/examples/password_manager/frontend/src/components/Vault.svelte
@@ -10,7 +10,7 @@
     import GiOpenTreasureChest from "svelte-icons/gi/GiOpenTreasureChest.svelte";
     import { auth } from "../store/auth";
     import SharingEditor from "./SharingEditor.svelte";
-    import type { AccessRights } from "ic_vetkeys/tools";
+    import type { AccessRights } from "@dfinity/vetkeys/tools";
 
     export let vault: VaultModel = {
         name: "",

--- a/examples/password_manager/frontend/src/lib/encrypted_maps.ts
+++ b/examples/password_manager/frontend/src/lib/encrypted_maps.ts
@@ -1,7 +1,7 @@
 import "./init.ts";
 import { HttpAgent, type HttpAgentOptions } from "@dfinity/agent";
-import { DefaultEncryptedMapsClient } from "ic_vetkeys/tools";
-import { EncryptedMaps } from "ic_vetkeys/tools";
+import { DefaultEncryptedMapsClient } from "@dfinity/vetkeys/tools";
+import { EncryptedMaps } from "@dfinity/vetkeys/tools";
 
 export async function createEncryptedMaps(
     agentOptions?: HttpAgentOptions,

--- a/examples/password_manager/frontend/src/lib/vault.ts
+++ b/examples/password_manager/frontend/src/lib/vault.ts
@@ -1,6 +1,6 @@
 import type { Principal } from "@dfinity/principal";
 import type { PasswordModel } from "./password";
-import type { AccessRights } from "ic_vetkeys/tools";
+import type { AccessRights } from "@dfinity/vetkeys/tools";
 
 export interface VaultModel {
     owner: Principal;

--- a/examples/password_manager/frontend/src/store/auth.ts
+++ b/examples/password_manager/frontend/src/store/auth.ts
@@ -4,7 +4,7 @@ import { AuthClient } from "@dfinity/auth-client";
 import type { JsonnableDelegationChain } from "@dfinity/identity/lib/cjs/identity/delegation";
 import { replace } from "svelte-spa-router";
 import { createEncryptedMaps } from "../lib/encrypted_maps.js";
-import { EncryptedMaps } from "ic_vetkeys/tools";
+import { EncryptedMaps } from "@dfinity/vetkeys/tools";
 
 export type AuthState =
     | {

--- a/examples/password_manager/frontend/src/store/vaults.ts
+++ b/examples/password_manager/frontend/src/store/vaults.ts
@@ -3,7 +3,7 @@ import { passwordFromContent, type PasswordModel } from "../lib/password";
 import { vaultFromContent, type VaultModel } from "../lib/vault";
 import { auth } from "./auth";
 import { showError } from "./notifications";
-import { type AccessRights, EncryptedMaps } from "ic_vetkeys/tools";
+import { type AccessRights, EncryptedMaps } from "@dfinity/vetkeys/tools";
 import type { Principal } from "@dfinity/principal";
 
 export const vaultsStore = writable<

--- a/examples/password_manager_with_metadata/frontend/package.json
+++ b/examples/password_manager_with_metadata/frontend/package.json
@@ -13,9 +13,6 @@
         "prettier-check": "prettier --check .",
         "preview": "vite preview"
     },
-    "peerDependencies": {
-        "ic_vetkeys": "^0.1.0"
-    },
     "devDependencies": {
         "@eslint/js": "^9.22.0",
         "@rollup/plugin-typescript": "^12.1.2",
@@ -52,5 +49,8 @@
         "svelte-spa-router": "^4.0.1",
         "tailwindcss": "^3.0.17",
         "typewriter-editor": "^0.9.4"
+    },
+    "peerDependencies": {
+        "@dfinity/vetkeys": "^0.1.0"
     }
 }

--- a/examples/password_manager_with_metadata/frontend/src/components/EditPassword.svelte
+++ b/examples/password_manager_with_metadata/frontend/src/components/EditPassword.svelte
@@ -12,7 +12,7 @@
     import Spinner from "./Spinner.svelte";
     import { onDestroy } from "svelte";
     import { Principal } from "@dfinity/principal";
-    import type { AccessRights } from "ic_vetkeys/tools";
+    import type { AccessRights } from "@dfinity/vetkeys/tools";
 
     export let currentRoute = "";
     const unsubscribe = location.subscribe((value) => {

--- a/examples/password_manager_with_metadata/frontend/src/components/SharingEditor.svelte
+++ b/examples/password_manager_with_metadata/frontend/src/components/SharingEditor.svelte
@@ -9,7 +9,7 @@
     } from "../store/vaults";
     import { addNotification, showError } from "../store/notifications";
     import { Principal } from "@dfinity/principal";
-    import type { AccessRights } from "ic_vetkeys/tools";
+    import type { AccessRights } from "@dfinity/vetkeys/tools";
 
     export let editedVault: VaultModel;
     export let canManage = false;

--- a/examples/password_manager_with_metadata/frontend/src/components/Vault.svelte
+++ b/examples/password_manager_with_metadata/frontend/src/components/Vault.svelte
@@ -10,7 +10,7 @@
     import GiOpenTreasureChest from "svelte-icons/gi/GiOpenTreasureChest.svelte";
     import { auth } from "../store/auth";
     import SharingEditor from "./SharingEditor.svelte";
-    import type { AccessRights } from "ic_vetkeys/tools";
+    import type { AccessRights } from "@dfinity/vetkeys/tools";
 
     export let vault: VaultModel = {
         name: "",

--- a/examples/password_manager_with_metadata/frontend/src/lib/encrypted_maps.ts
+++ b/examples/password_manager_with_metadata/frontend/src/lib/encrypted_maps.ts
@@ -1,7 +1,7 @@
 import "./init.ts";
 import { HttpAgent, type HttpAgentOptions } from "@dfinity/agent";
-import { DefaultEncryptedMapsClient } from "ic_vetkeys/tools";
-import { EncryptedMaps } from "ic_vetkeys/tools";
+import { DefaultEncryptedMapsClient } from "@dfinity/vetkeys/tools";
+import { EncryptedMaps } from "@dfinity/vetkeys/tools";
 
 export async function createEncryptedMaps(
     agentOptions: HttpAgentOptions,

--- a/examples/password_manager_with_metadata/frontend/src/lib/password_manager.ts
+++ b/examples/password_manager_with_metadata/frontend/src/lib/password_manager.ts
@@ -1,6 +1,6 @@
 import "./init.ts";
 import { type ActorSubclass, type HttpAgentOptions } from "@dfinity/agent";
-import { EncryptedMaps } from "ic_vetkeys/tools";
+import { EncryptedMaps } from "@dfinity/vetkeys/tools";
 import { createEncryptedMaps } from "./encrypted_maps";
 import type { Principal } from "@dfinity/principal";
 import { createActor } from "../declarations/index";

--- a/examples/password_manager_with_metadata/frontend/src/lib/vault.ts
+++ b/examples/password_manager_with_metadata/frontend/src/lib/vault.ts
@@ -1,6 +1,6 @@
 import type { Principal } from "@dfinity/principal";
 import type { PasswordModel } from "./password";
-import type { AccessRights } from "ic_vetkeys/tools";
+import type { AccessRights } from "@dfinity/vetkeys/tools";
 
 export interface VaultModel {
     owner: Principal;

--- a/examples/password_manager_with_metadata/frontend/src/store/vaults.ts
+++ b/examples/password_manager_with_metadata/frontend/src/store/vaults.ts
@@ -3,7 +3,7 @@ import { type PasswordModel } from "../lib/password";
 import { type VaultModel } from "../lib/vault";
 import { auth, type AuthState } from "./auth";
 import { showError } from "./notifications";
-import { type AccessRights } from "ic_vetkeys/tools";
+import { type AccessRights } from "@dfinity/vetkeys/tools";
 import type { Principal } from "@dfinity/principal";
 import type { PasswordManager } from "../lib/password_manager";
 

--- a/frontend/ic_vetkeys/eslint.config.mjs
+++ b/frontend/ic_vetkeys/eslint.config.mjs
@@ -21,6 +21,7 @@ export default tseslint.config(
         ignores: [
             "dist/",
             "src/declarations",
+            "coverage/",
             "*.config.js",
             "*.config.cjs",
             "*.config.mjs",

--- a/frontend/ic_vetkeys/package.json
+++ b/frontend/ic_vetkeys/package.json
@@ -1,7 +1,42 @@
 {
-    "name": "ic_vetkeys",
+    "name": "@dfinity/vetkeys",
     "version": "0.1.0",
+    "author": "DFINITY Stiftung <sdk@dfinity.org>",
+    "description": "JavaScript and TypeScript library to interact with vetKeys on the Internet Computer",
+    "homepage": "https://internetcomputer.org/docs/building-apps/network-features/encryption/vetkeys",
     "license": "Apache-2.0",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/dfinity/vetkd-devkit.git",
+        "directory": "frontend/ic_vetkeys"
+    },
+    "bugs": {
+        "url": "https://github.com/dfinity/vetkd-devkit/issues"
+    },
+    "keywords": [
+        "internet computer",
+        "internet-computer",
+        "ic",
+        "icp",
+        "dfinity",
+        "vetkeys",
+        "encryption",
+        "decryption",
+        "threshold",
+        "motoko",
+        "rust",
+        "javascript",
+        "typescript",
+        "blockchain",
+        "crypto",
+        "distributed",
+        "api",
+        "bls",
+        "bls12-381",
+        "ibe",
+        "signature",
+        "signing"
+    ],
     "files": [
         "dist"
     ],
@@ -41,7 +76,7 @@
     },
     "scripts": {
         "build": "tsc && vite build",
-        "coverage": "vitest run --coverage",
+        "coverage": "npm run test:deploy_all && export $(cat .test1.env .test2.env | xargs) && vitest run --coverage",
         "lint": "eslint",
         "make:docs": "mkdir -p $(git rev-parse --show-toplevel)/docs/tools && typedoc --out $(git rev-parse --show-toplevel)/docs",
         "prettier": "prettier --write .",

--- a/frontend/ic_vetkeys/package.json
+++ b/frontend/ic_vetkeys/package.json
@@ -2,7 +2,7 @@
     "name": "@dfinity/vetkeys",
     "version": "0.1.0",
     "author": "DFINITY Stiftung <sdk@dfinity.org>",
-    "description": "JavaScript and TypeScript library to interact with vetKeys on the Internet Computer",
+    "description": "JavaScript and TypeScript library to use Internet Computer vetKeys",
     "homepage": "https://internetcomputer.org/docs/building-apps/network-features/encryption/vetkeys",
     "license": "Apache-2.0",
     "repository": {

--- a/frontend/ic_vetkeys/src/encrypted_maps/encrypted_maps.ts
+++ b/frontend/ic_vetkeys/src/encrypted_maps/encrypted_maps.ts
@@ -35,7 +35,7 @@ import {
  *
  * @example
  * ```ts
- * import { EncryptedMaps } from "ic_vetkeys/tools";
+ * import { EncryptedMaps } from "@dfinity/vetkeys/tools";
  *
  * // Initialize the EncryptedMaps Client
  * const encryptedMaps = new EncryptedMaps(encryptedMapsClientInstance);
@@ -76,7 +76,7 @@ export class EncryptedMaps {
      *
      * @example
      * ```ts
-     * import { EncryptedMaps } from "ic_vetkeys/tools";
+     * import { EncryptedMaps } from "@dfinity/vetkeys/tools";
      *
      * const encryptedMaps = new EncryptedMaps(encryptedMapsClientInstance);
      * ```

--- a/frontend/ic_vetkeys/src/key_manager/key_manager.ts
+++ b/frontend/ic_vetkeys/src/key_manager/key_manager.ts
@@ -32,7 +32,7 @@ import {
  *
  * @example
  * ```ts
- * import { KeyManager } from "ic_vetkeys/tools";
+ * import { KeyManager } from "@dfinity/vetkeys/tools";
  *
  * // Initialize the KeyManager
  * const keyManager = new KeyManager(keyManagerClientInstance);
@@ -62,7 +62,7 @@ export class KeyManager {
      *
      * @example
      * ```ts
-     * import { KeyManager } from "ic_vetkeys/tools";
+     * import { KeyManager } from "@dfinity/vetkeys/tools";
      *
      * const keyManager = new KeyManager(keyManagerClientInstance);
      * ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,10 @@
                 "examples/basic_ibe/frontend",
                 "examples/password_manager/frontend",
                 "examples/password_manager_with_metadata/frontend"
-            ]
+            ],
+            "peerDependencies": {
+                "@dfinity/vetkeys": "^0.1.0"
+            }
         },
         "examples/basic_ibe/frontend": {
             "version": "0.0.0",
@@ -26,7 +29,7 @@
                 "vite-plugin-environment": "^1.1.3"
             },
             "peerDependencies": {
-                "ic_vetkeys": "^0.1.0"
+                "@dfinity/vetkeys": "^0.1.0"
             }
         },
         "examples/basic_ibe/frontend/node_modules/typescript": {
@@ -85,7 +88,7 @@
                 "vite-plugin-eslint": "^1.8.1"
             },
             "peerDependencies": {
-                "ic_vetkeys": "^0.1.0"
+                "@dfinity/vetkeys": "^0.1.0"
             }
         },
         "examples/password_manager_with_metadata/frontend/node_modules/@esbuild/aix-ppc64": {
@@ -722,7 +725,7 @@
                 "vite-plugin-environment": "^1.1.3"
             },
             "peerDependencies": {
-                "ic_vetkeys": "^0.1.0"
+                "@dfinity/vetkeys": "^0.1.0"
             }
         },
         "examples/password_manager/frontend/node_modules/@esbuild/aix-ppc64": {
@@ -1452,6 +1455,7 @@
             }
         },
         "frontend/ic_vetkeys": {
+            "name": "@dfinity/vetkeys",
             "version": "0.1.0",
             "license": "Apache-2.0",
             "dependencies": {
@@ -1792,6 +1796,10 @@
             "dependencies": {
                 "@noble/hashes": "^1.3.1"
             }
+        },
+        "node_modules/@dfinity/vetkeys": {
+            "resolved": "frontend/ic_vetkeys",
+            "link": true
         },
         "node_modules/@esbuild/aix-ppc64": {
             "version": "0.25.2",
@@ -6386,10 +6394,6 @@
             "engines": {
                 "node": ">= 14"
             }
-        },
-        "node_modules/ic_vetkeys": {
-            "resolved": "frontend/ic_vetkeys",
-            "link": true
         },
         "node_modules/iconv-lite": {
             "version": "0.6.3",


### PR DESCRIPTION
- Changed the name of the package to `@dfinity/vetkeys`. (Having `ic_` prefix would be unexpected given that no other package in the `@dfinity` scope has such a prefix and they all are about IC.)
- Added some metadata like keywords, URLs, etc. to `package.json`.
- As a side-effect of looking at it, fixed the `coverage` script, since it requires canister deployment, and added an ignore to eslint for coverage.