### PR TITLE
chore: fix ci by fixing two failing tests and add a workflow dependency

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths:
       - frontend/ic_vetkeys/**
+      - backend/**
       - package.json
       - package-lock.json
       - .github/workflows/frontend_ic_vetkeys.yml

--- a/frontend/ic_vetkeys/src/encrypted_maps/encrypted_maps_canister.test.ts
+++ b/frontend/ic_vetkeys/src/encrypted_maps/encrypted_maps_canister.test.ts
@@ -223,7 +223,7 @@ test("can get user rights", async () => {
     const user = id1.getPrincipal();
     const encryptedMapsOwner = await newEncryptedMaps(id0);
     const encryptedMapsUser = await newEncryptedMaps(id1);
-    const rights = { ReadWrite: null };
+    const rights = { ReadWriteManage: null };
 
     await encryptedMapsOwner.setValue(
         owner,

--- a/frontend/ic_vetkeys/src/key_manager/key_manager_canister.test.ts
+++ b/frontend/ic_vetkeys/src/key_manager/key_manager_canister.test.ts
@@ -116,7 +116,7 @@ test("sharing rights are consistent", async () => {
     const keyManagerUser = await newKeyManager(id1).catch((err) => {
         throw err;
     });
-    const rights = { ReadWrite: null };
+    const rights = { ReadWriteManage: null };
 
     expect(
         await keyManagerOwner.setUserRights(

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,7 @@
                 "examples/basic_ibe/frontend",
                 "examples/password_manager/frontend",
                 "examples/password_manager_with_metadata/frontend"
-            ],
-            "peerDependencies": {
-                "@dfinity/vetkeys": "^0.1.0"
-            }
+            ]
         },
         "examples/basic_ibe/frontend": {
             "version": "0.0.0",


### PR DESCRIPTION
The workflow dependency is due to the frontend tests being dependent on backend canisters.